### PR TITLE
Fix Hwyla tooltip always displaying entities as hungry and thirsty (animania#484)

### DIFF
--- a/src/main/java/com/animania/compat/waila/provider/WailaEntityAnimalProviderBase.java
+++ b/src/main/java/com/animania/compat/waila/provider/WailaEntityAnimalProviderBase.java
@@ -4,6 +4,17 @@ import java.util.List;
 
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.ISpawnable;
+import com.animania.common.entities.chickens.EntityAnimaniaChicken;
+import com.animania.common.entities.cows.EntityAnimaniaCow;
+import com.animania.common.entities.goats.EntityAnimaniaGoat;
+import com.animania.common.entities.horses.EntityAnimaniaHorse;
+import com.animania.common.entities.peacocks.EntityAnimaniaPeacock;
+import com.animania.common.entities.pigs.EntityAnimaniaPig;
+import com.animania.common.entities.rodents.EntityFerretBase;
+import com.animania.common.entities.rodents.EntityHamster;
+import com.animania.common.entities.rodents.EntityHedgehogBase;
+import com.animania.common.entities.rodents.rabbits.EntityAnimaniaRabbit;
+import com.animania.common.entities.sheep.EntityAnimaniaSheep;
 import com.animania.config.AnimaniaConfig;
 
 import mcp.mobius.waila.api.IWailaConfigHandler;
@@ -35,8 +46,8 @@ public class WailaEntityAnimalProviderBase implements IWailaEntityProvider
 	public List<String> getWailaBody(Entity entity, List<String> currenttip, IWailaEntityAccessor accessor, IWailaConfigHandler config)
 	{
 		NBTTagCompound comp = accessor.getNBTData();
-		boolean fed = accessor.getNBTData().getBoolean("Fed");
-		boolean watered = accessor.getNBTData().getBoolean("Watered");
+		boolean fed = comp.getBoolean("Fed");
+		boolean watered = comp.getBoolean("Watered");
 		
 		if (fed && watered && !AnimaniaConfig.gameRules.ambianceMode)
 			currenttip.add(I18n.translateToLocal("text.waila.fed"));
@@ -60,13 +71,60 @@ public class WailaEntityAnimalProviderBase implements IWailaEntityProvider
 	}
 
 	@Override
-	public NBTTagCompound getNBTData(EntityPlayerMP player, Entity ent, NBTTagCompound tag, World world)
+	public NBTTagCompound getNBTData(EntityPlayerMP player, Entity entity, NBTTagCompound tag, World world)
 	{
-		NBTTagCompound comp = ent.getEntityData();
+		boolean fed = false;
+		boolean watered = false;
 
-		tag.setBoolean("Fed", comp.getBoolean("Fed"));
-		tag.setBoolean("Watered", comp.getBoolean("Watered"));
-		
+		if (entity instanceof EntityAnimaniaChicken) {
+			EntityAnimaniaChicken tempEnt = (EntityAnimaniaChicken) entity;
+			fed = tempEnt.getFed();
+			watered = tempEnt.getWatered();
+		} else if (entity instanceof EntityAnimaniaCow) {
+			EntityAnimaniaCow tempEnt = (EntityAnimaniaCow) entity;
+			fed = tempEnt.getFed();
+			watered = tempEnt.getWatered();
+		} else if (entity instanceof EntityAnimaniaGoat) {
+			EntityAnimaniaGoat tempEnt = (EntityAnimaniaGoat) entity;
+			fed = tempEnt.getFed();
+			watered = tempEnt.getWatered();
+		} else if (entity instanceof EntityAnimaniaHorse) {
+			EntityAnimaniaHorse tempEnt = (EntityAnimaniaHorse) entity;
+			fed = tempEnt.getFed();
+			watered = tempEnt.getWatered();
+		} else if (entity instanceof EntityAnimaniaPeacock) {
+			EntityAnimaniaPeacock tempEnt = (EntityAnimaniaPeacock) entity;
+			fed = tempEnt.getFed();
+			watered = tempEnt.getWatered();
+		} else if (entity instanceof EntityAnimaniaPig) {
+			EntityAnimaniaPig tempEnt = (EntityAnimaniaPig) entity;
+			fed = tempEnt.getFed();
+			watered = tempEnt.getWatered();
+		} else if (entity instanceof EntityAnimaniaRabbit) {
+			EntityAnimaniaRabbit tempEnt = (EntityAnimaniaRabbit) entity;
+			fed = tempEnt.getFed();
+			watered = tempEnt.getWatered();
+		} else if (entity instanceof EntityAnimaniaSheep) {
+			EntityAnimaniaSheep tempEnt = (EntityAnimaniaSheep) entity;
+			fed = tempEnt.getFed();
+			watered = tempEnt.getWatered();
+		} else if (entity instanceof EntityHedgehogBase) {
+			EntityHedgehogBase tempEnt = (EntityHedgehogBase) entity;
+			fed = tempEnt.getFed();
+			watered = tempEnt.getWatered();
+		} else if (entity instanceof EntityFerretBase) {
+			EntityFerretBase tempEnt = (EntityFerretBase) entity;
+			fed = tempEnt.getFed();
+			watered = tempEnt.getWatered();
+		} else if (entity instanceof EntityHamster) {
+			EntityHamster tempEnt = (EntityHamster) entity;
+			fed = tempEnt.getFed();
+			watered = tempEnt.getWatered();
+		}
+
+		tag.setBoolean("Fed", fed);
+		tag.setBoolean("Watered", watered);
+
 		return tag;
 	}
 


### PR DESCRIPTION
Issue link: https://github.com/capnkirok/animania/issues/484
Explained here: https://github.com/TehNut/HWYLA/issues/109#issuecomment-368218386

This retains compatibility with normal Waila as the tags set by the NBT provider are the same as the entity's serialized tags.

This change should also be applied in 1.12, but this'll do for now. It is now 2:30am so I'm going to go pass out for a few hours.