### PR TITLE
Recycle a single Random instance

### DIFF
--- a/src/main/java/com/animania/Animania.java
+++ b/src/main/java/com/animania/Animania.java
@@ -1,5 +1,7 @@
 package com.animania;
 
+import java.util.Random;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -44,6 +46,7 @@ public class Animania
 	
 	
 	public static SimpleNetworkWrapper network;
+	public static Random RANDOM = new Random();
 
 	//GUI
 	public static int horseCartGUI_ID = 0;

--- a/src/main/java/com/animania/addons/catsdogs/common/entity/cats/CatType.java
+++ b/src/main/java/com/animania/addons/catsdogs/common/entity/cats/CatType.java
@@ -2,8 +2,8 @@ package com.animania.addons.catsdogs.common.entity.cats;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Random;
 
+import com.animania.Animania;
 import com.animania.common.entities.AnimaniaType;
 import com.animania.common.entities.cows.CowType;
 import com.animania.common.entities.cows.EntityBullBase;
@@ -106,11 +106,7 @@ public enum CatType implements AnimaniaType
 
 	public static CatType breed(CatType male, CatType female)
 	{
-		Random rand = new Random();
-		if(rand.nextInt(2) == 0)
-			return male;
-		else
-			return female;
+		return Animania.RANDOM.nextBoolean() ? male : female;
 	}
 
 }

--- a/src/main/java/com/animania/addons/catsdogs/common/entity/cats/EntityKittenBase.java
+++ b/src/main/java/com/animania/addons/catsdogs/common/entity/cats/EntityKittenBase.java
@@ -1,10 +1,10 @@
 package com.animania.addons.catsdogs.common.entity.cats;
 
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.generic.ai.GenericAIFollowParents;
@@ -155,8 +155,7 @@ public class EntityKittenBase extends EntityAnimaniaCat implements TOPInfoProvid
 		else
 			num = 32;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.piglet1;
@@ -176,8 +175,7 @@ public class EntityKittenBase extends EntityAnimaniaCat implements TOPInfoProvid
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.pigletHurt1;
@@ -190,8 +188,7 @@ public class EntityKittenBase extends EntityAnimaniaCat implements TOPInfoProvid
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.pigletHurt1;

--- a/src/main/java/com/animania/addons/catsdogs/common/entity/cats/EntityQueenBase.java
+++ b/src/main/java/com/animania/addons/catsdogs/common/entity/cats/EntityQueenBase.java
@@ -1,11 +1,11 @@
 package com.animania.addons.catsdogs.common.entity.cats;
 
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
 
+import com.animania.Animania;
 import com.animania.addons.catsdogs.config.CatsDogsConfig;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
@@ -283,8 +283,7 @@ public class EntityQueenBase extends EntityAnimaniaCat implements TOPInfoProvide
 		else
 			num = 40;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.pig1;
@@ -306,8 +305,7 @@ public class EntityQueenBase extends EntityAnimaniaCat implements TOPInfoProvide
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.pigHurt1;
@@ -320,8 +318,7 @@ public class EntityQueenBase extends EntityAnimaniaCat implements TOPInfoProvide
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.pigHurt1;

--- a/src/main/java/com/animania/addons/catsdogs/common/entity/cats/EntityTomBase.java
+++ b/src/main/java/com/animania/addons/catsdogs/common/entity/cats/EntityTomBase.java
@@ -2,7 +2,6 @@ package com.animania.addons.catsdogs.common.entity.cats;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -20,6 +19,7 @@ import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.cows.EntityBullBase;
@@ -130,8 +130,7 @@ public class EntityTomBase extends EntityAnimaniaCat implements TOPInfoProviderM
 		else
 			num = 40;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.hog1;
@@ -157,8 +156,7 @@ public class EntityTomBase extends EntityAnimaniaCat implements TOPInfoProviderM
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.pigHurt1;
@@ -171,8 +169,7 @@ public class EntityTomBase extends EntityAnimaniaCat implements TOPInfoProviderM
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.pigHurt1;

--- a/src/main/java/com/animania/client/models/ModelChick.java
+++ b/src/main/java/com/animania/client/models/ModelChick.java
@@ -1,7 +1,5 @@
 package com.animania.client.models;
 
-import java.util.Random;
-
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.entity.Entity;
@@ -160,7 +158,6 @@ public class ModelChick extends ModelBase
     public void setLivingAnimations(EntityLivingBase entitylivingbaseIn, float limbSwingAmount, float ageInTicks, float partialTickTime) {
 
         super.setLivingAnimations(entitylivingbaseIn, limbSwingAmount, ageInTicks, partialTickTime);
-        Random rand = new Random();
         if (limbSwingAmount > this.lastLimb)
             this.Neck.rotateAngleX = Math.abs(30F / (float) Math.PI * 1.4F * limbSwingAmount);
         else {

--- a/src/main/java/com/animania/client/models/ModelPeachick.java
+++ b/src/main/java/com/animania/client/models/ModelPeachick.java
@@ -1,7 +1,5 @@
 package com.animania.client.models;
 
-import java.util.Random;
-
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.entity.Entity;
@@ -217,7 +215,6 @@ public class ModelPeachick extends ModelBase
     public void setLivingAnimations(EntityLivingBase entitylivingbaseIn, float limbSwingAmount, float ageInTicks, float partialTickTime) {
 
         super.setLivingAnimations(entitylivingbaseIn, limbSwingAmount, ageInTicks, partialTickTime);
-        Random rand = new Random();
         if (limbSwingAmount > this.lastLimb) {
             // this.Neck.rotateAngleX = Math.abs(((30F / (float)Math.PI)) * 1.4F
             // * limbSwingAmount);

--- a/src/main/java/com/animania/client/models/ModelPeafowl.java
+++ b/src/main/java/com/animania/client/models/ModelPeafowl.java
@@ -1,7 +1,5 @@
 package com.animania.client.models;
 
-import java.util.Random;
-
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.entity.Entity;
@@ -224,7 +222,6 @@ public class ModelPeafowl extends ModelBase
     public void setLivingAnimations(EntityLivingBase entitylivingbaseIn, float limbSwingAmount, float ageInTicks, float partialTickTime) {
 
         super.setLivingAnimations(entitylivingbaseIn, limbSwingAmount, ageInTicks, partialTickTime);
-        Random rand = new Random();
         if (limbSwingAmount > this.lastLimb) {
             // this.Neck.rotateAngleX = Math.abs(((30F / (float)Math.PI)) * 1.4F
             // * limbSwingAmount);

--- a/src/main/java/com/animania/client/models/ModelRendererBall.java
+++ b/src/main/java/com/animania/client/models/ModelRendererBall.java
@@ -1,7 +1,5 @@
 package com.animania.client.models;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.Minecraft;

--- a/src/main/java/com/animania/client/render/cows/RenderBullAngus.java
+++ b/src/main/java/com/animania/client/render/cows/RenderBullAngus.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelBullAngus;
@@ -25,7 +23,6 @@ public class RenderBullAngus<T extends EntityBullAngus> extends RenderLiving<T>
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation cowTextures = new ResourceLocation("animania:textures/entity/cows/bull_angus.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/bull_blink.png");
-	Random rand = new Random();
 
 	public RenderBullAngus(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/cows/RenderBullFriesian.java
+++ b/src/main/java/com/animania/client/render/cows/RenderBullFriesian.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelBull;
@@ -27,7 +25,6 @@ public class RenderBullFriesian<T extends EntityBullFriesian> extends RenderLivi
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/bull_blink.png");
 	private static final ResourceLocation purpTextures = new ResourceLocation("animania:textures/entity/cows/bull_purplicious.png");
 	private static final ResourceLocation purpTexturesBlink = new ResourceLocation("animania:textures/entity/cows/bull_purplicious.png");
-	Random rand = new Random();
 
 	LayerBlinking blinkingLayer;
 	

--- a/src/main/java/com/animania/client/render/cows/RenderBullHereford.java
+++ b/src/main/java/com/animania/client/render/cows/RenderBullHereford.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelBullHereford;
@@ -25,7 +23,6 @@ public class RenderBullHereford<T extends EntityBullHereford> extends RenderLivi
 
 	private static final ResourceLocation cowTextures = new ResourceLocation("animania:textures/entity/cows/bull_hereford.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/bull_blink.png");
-	Random rand = new Random();
 
 	public RenderBullHereford(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/cows/RenderBullHighland.java
+++ b/src/main/java/com/animania/client/render/cows/RenderBullHighland.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelBullLonghorn;
@@ -24,7 +22,6 @@ public class RenderBullHighland<T extends EntityBullHighland> extends RenderLivi
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation cowTextures = new ResourceLocation("animania:textures/entity/cows/bull_highland.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/bull_blink.png");
-	Random rand = new Random();
 
 	public RenderBullHighland(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/cows/RenderBullHolstein.java
+++ b/src/main/java/com/animania/client/render/cows/RenderBullHolstein.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelBull;
@@ -27,7 +25,6 @@ public class RenderBullHolstein<T extends EntityBullHolstein> extends RenderLivi
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/bull_blink.png");
 	private static final ResourceLocation purpTextures = new ResourceLocation("animania:textures/entity/cows/bull_purplicious.png");
 	private static final ResourceLocation purpTexturesBlink = new ResourceLocation("animania:textures/entity/cows/bull_purplicious.png");
-	Random rand = new Random();
 
 	LayerBlinking blinkingLayer;
 	

--- a/src/main/java/com/animania/client/render/cows/RenderBullJersey.java
+++ b/src/main/java/com/animania/client/render/cows/RenderBullJersey.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelBullHereford;
@@ -25,7 +23,6 @@ public class RenderBullJersey<T extends EntityBullJersey> extends RenderLiving<T
 
 	private static final ResourceLocation cowTextures = new ResourceLocation("animania:textures/entity/cows/bull_jersey.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/bull_blink.png");
-	Random rand = new Random();
 
 	public RenderBullJersey(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/cows/RenderBullLonghorn.java
+++ b/src/main/java/com/animania/client/render/cows/RenderBullLonghorn.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelBullLonghorn;
@@ -25,7 +23,6 @@ public class RenderBullLonghorn<T extends EntityBullLonghorn> extends RenderLivi
 
 	private static final ResourceLocation cowTextures = new ResourceLocation("animania:textures/entity/cows/bull_longhorn.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/bull_blink.png");
-	Random rand = new Random();
 
 	public RenderBullLonghorn(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/cows/RenderBullMooshroom.java
+++ b/src/main/java/com/animania/client/render/cows/RenderBullMooshroom.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelBull;
@@ -27,7 +25,6 @@ public class RenderBullMooshroom<T extends EntityBullMooshroom> extends RenderLi
 
 	private static final ResourceLocation cowTextures = new ResourceLocation("animania:textures/entity/cows/bull_mooshroom.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/bull_blink.png");
-	Random rand = new Random();
 
 	public RenderBullMooshroom(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/cows/RenderCalfAngus.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCalfAngus.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCalf;
@@ -26,7 +24,6 @@ public class RenderCalfAngus<T extends EntityCalfAngus> extends RenderLiving<T>
 
 	private static final ResourceLocation cowTextures = new ResourceLocation("animania:textures/entity/cows/calf_angus.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/calf_blink.png");
-	Random rand = new Random();
 
 	public RenderCalfAngus(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/cows/RenderCalfFriesian.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCalfFriesian.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCalf;
@@ -27,7 +25,6 @@ public class RenderCalfFriesian<T extends EntityCalfFriesian> extends RenderLivi
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/calf_blink.png");
 	private static final ResourceLocation purpTextures = new ResourceLocation("animania:textures/entity/cows/calf_purplicious.png");
 	private static final ResourceLocation purpTexturesBlink = new ResourceLocation("animania:textures/entity/cows/calf_purplicious.png");
-	Random rand = new Random();
 
 	private LayerBlinking blinkingLayer;
 

--- a/src/main/java/com/animania/client/render/cows/RenderCalfHereford.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCalfHereford.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCalf;
@@ -25,7 +23,6 @@ public class RenderCalfHereford<T extends EntityCalfHereford> extends RenderLivi
 
 	private static final ResourceLocation cowTextures      = new ResourceLocation("animania:textures/entity/cows/calf_hereford.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/calf_blink.png");
-	Random                                rand             = new Random();
 
 	public RenderCalfHereford(RenderManager rm) {
 		super(rm, new ModelCalf(), 0.5F);

--- a/src/main/java/com/animania/client/render/cows/RenderCalfHighland.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCalfHighland.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCalfLonghorn;
@@ -24,7 +22,6 @@ public class RenderCalfHighland<T extends EntityCalfHighland> extends RenderLivi
 	public static final Factory           FACTORY          = new Factory();
 	private static final ResourceLocation cowTextures      = new ResourceLocation("animania:textures/entity/cows/calf_highland.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/calf_blink.png");
-	Random                                rand             = new Random();
 
 	public RenderCalfHighland(RenderManager rm) {
 		super(rm, new ModelCalfLonghorn(), 0.5F);

--- a/src/main/java/com/animania/client/render/cows/RenderCalfHolstein.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCalfHolstein.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCalf;
@@ -27,7 +25,6 @@ public class RenderCalfHolstein<T extends EntityCalfHolstein> extends RenderLivi
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/calf_blink.png");
 	private static final ResourceLocation purpTextures = new ResourceLocation("animania:textures/entity/cows/calf_purplicious.png");
 	private static final ResourceLocation purpTexturesBlink = new ResourceLocation("animania:textures/entity/cows/calf_purplicious.png");
-	Random rand = new Random();
 
 	private LayerBlinking blinkingLayer;
 

--- a/src/main/java/com/animania/client/render/cows/RenderCalfJersey.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCalfJersey.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCalf;
@@ -25,7 +23,6 @@ public class RenderCalfJersey<T extends EntityCalfJersey> extends RenderLiving<T
 
     private static final ResourceLocation cowTextures      = new ResourceLocation("animania:textures/entity/cows/calf_jersey.png");
     private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/calf_blink.png");
-    Random                                rand             = new Random();
 
     public RenderCalfJersey(RenderManager rm) {
         super(rm, new ModelCalf(), 0.5F);

--- a/src/main/java/com/animania/client/render/cows/RenderCalfLonghorn.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCalfLonghorn.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCalfLonghorn;
@@ -25,7 +23,6 @@ public class RenderCalfLonghorn<T extends EntityCalfLonghorn> extends RenderLivi
 
     private static final ResourceLocation cowTextures      = new ResourceLocation("animania:textures/entity/cows/calf_longhorn.png");
     private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/calf_blink.png");
-    Random                                rand             = new Random();
 
     public RenderCalfLonghorn(RenderManager rm) {
         super(rm, new ModelCalfLonghorn(), 0.5F);

--- a/src/main/java/com/animania/client/render/cows/RenderCalfMooshroom.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCalfMooshroom.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCalf;
@@ -25,7 +23,6 @@ public class RenderCalfMooshroom<T extends EntityCalfMooshroom> extends RenderLi
 
 	private static final ResourceLocation cowTextures = new ResourceLocation("animania:textures/entity/cows/calf_mooshroom.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/calf_blink.png");
-	Random rand = new Random();
 
 	public RenderCalfMooshroom(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/cows/RenderCowAngus.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCowAngus.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCowAngus;
@@ -25,7 +23,6 @@ public class RenderCowAngus<T extends EntityCowAngus> extends RenderLiving<T>
 
 	private static final ResourceLocation cowTextures = new ResourceLocation("animania:textures/entity/cows/cow_angus.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/cow_blink.png");
-	Random rand = new Random();
 
 	public RenderCowAngus(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/cows/RenderCowFriesian.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCowFriesian.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCow;
@@ -27,7 +25,6 @@ public class RenderCowFriesian<T extends EntityCowFriesian> extends RenderLiving
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/cow_blink.png");
 	private static final ResourceLocation purpTextures = new ResourceLocation("animania:textures/entity/cows/cow_purplicious.png");
 	private static final ResourceLocation purpTexturesBlink = new ResourceLocation("animania:textures/entity/cows/cow_purplicious.png");
-	Random rand = new Random();
 
 	LayerBlinking blinkingLayer;
 

--- a/src/main/java/com/animania/client/render/cows/RenderCowHereford.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCowHereford.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCowHereford;
@@ -27,7 +25,6 @@ public class RenderCowHereford<T extends EntityCowHereford> extends RenderLiving
 
 	private static final ResourceLocation cowTextures = new ResourceLocation("animania:textures/entity/cows/cow_hereford.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/cow_blink.png");
-	Random rand = new Random();
 
 	public RenderCowHereford(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/cows/RenderCowHighland.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCowHighland.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCowLonghorn;
@@ -24,7 +22,6 @@ public class RenderCowHighland<T extends EntityCowHighland> extends RenderLiving
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation cowTextures = new ResourceLocation("animania:textures/entity/cows/cow_highland.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/cow_blink.png");
-	Random rand = new Random();
 
 	public RenderCowHighland(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/cows/RenderCowHolstein.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCowHolstein.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCow;
@@ -27,7 +25,6 @@ public class RenderCowHolstein<T extends EntityCowHolstein> extends RenderLiving
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/cow_blink.png");
 	private static final ResourceLocation purpTextures = new ResourceLocation("animania:textures/entity/cows/cow_purplicious.png");
 	private static final ResourceLocation purpTexturesBlink = new ResourceLocation("animania:textures/entity/cows/cow_purplicious.png");
-	Random rand = new Random();
 
 	LayerBlinking blinkingLayer;
 

--- a/src/main/java/com/animania/client/render/cows/RenderCowJersey.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCowJersey.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCowHereford;
@@ -25,7 +23,6 @@ public class RenderCowJersey<T extends EntityCowJersey> extends RenderLiving<T>
 
 	private static final ResourceLocation cowTextures = new ResourceLocation("animania:textures/entity/cows/cow_jersey.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/cow_blink.png");
-	Random rand = new Random();
 
 	public RenderCowJersey(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/cows/RenderCowLonghorn.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCowLonghorn.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCowLonghorn;
@@ -25,7 +23,6 @@ public class RenderCowLonghorn<T extends EntityCowLonghorn> extends RenderLiving
 
 	private static final ResourceLocation cowTextures = new ResourceLocation("animania:textures/entity/cows/cow_longhorn.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/cow_blink.png");
-	Random rand = new Random();
 
 	public RenderCowLonghorn(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/cows/RenderCowMooshroom.java
+++ b/src/main/java/com/animania/client/render/cows/RenderCowMooshroom.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.cows;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelCow;
@@ -27,8 +25,6 @@ public class RenderCowMooshroom<T extends EntityCowMooshroom> extends RenderLivi
 
 	private static final ResourceLocation cowTextures = new ResourceLocation("animania:textures/entity/cows/cow_mooshroom.png");
 	private static final ResourceLocation cowTexturesBlink = new ResourceLocation("animania:textures/entity/cows/cow_blink.png");
-
-	Random rand = new Random();
 
 	public RenderCowMooshroom(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderBuckAlpine.java
+++ b/src/main/java/com/animania/client/render/goats/RenderBuckAlpine.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelBuckAlpine;
@@ -24,7 +22,6 @@ public class RenderBuckAlpine<T extends EntityBuckAlpine> extends RenderLiving<T
     public static final Factory           FACTORY          = new Factory();
     private static final ResourceLocation goatTextures      = new ResourceLocation("animania:textures/entity/goats/buck_alpine.png");
     private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-    Random                                rand             = new Random();
 
     public RenderBuckAlpine(RenderManager rm) {
         super(rm, new ModelBuckAlpine(), 0.5F);

--- a/src/main/java/com/animania/client/render/goats/RenderBuckAngora.java
+++ b/src/main/java/com/animania/client/render/goats/RenderBuckAngora.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelBuckAngora;
@@ -26,7 +24,6 @@ public class RenderBuckAngora<T extends EntityBuckAngora> extends RenderLiving<T
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/angora_blink.png");
 	private static final ResourceLocation goatTexturesSheared = new ResourceLocation("animania:textures/entity/goats/buck_angora_sheared.png");
 	private static final ResourceLocation goatTexturesShearedBlink = new ResourceLocation("animania:textures/entity/goats/angora_blink.png");
-	Random rand = new Random();
 
 	public RenderBuckAngora(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderBuckFainting.java
+++ b/src/main/java/com/animania/client/render/goats/RenderBuckFainting.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelBuckFainting;
@@ -24,7 +22,6 @@ public class RenderBuckFainting<T extends EntityBuckFainting> extends RenderLivi
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation goatTextures = new ResourceLocation("animania:textures/entity/goats/buck_fainting.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderBuckFainting(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderBuckKiko.java
+++ b/src/main/java/com/animania/client/render/goats/RenderBuckKiko.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelBullAngus;
@@ -26,7 +24,6 @@ public class RenderBuckKiko<T extends EntityBuckKiko> extends RenderLiving<T>
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation goatTextures = new ResourceLocation("animania:textures/entity/goats/buck_kiko.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderBuckKiko(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderBuckKinder.java
+++ b/src/main/java/com/animania/client/render/goats/RenderBuckKinder.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelBullAngus;
@@ -26,7 +24,6 @@ public class RenderBuckKinder<T extends EntityBuckKinder> extends RenderLiving<T
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation goatTextures = new ResourceLocation("animania:textures/entity/goats/buck_kinder.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderBuckKinder(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderBuckNigerianDwarf.java
+++ b/src/main/java/com/animania/client/render/goats/RenderBuckNigerianDwarf.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelBullAngus;
@@ -26,7 +24,6 @@ public class RenderBuckNigerianDwarf<T extends EntityBuckNigerianDwarf> extends 
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation goatTextures = new ResourceLocation("animania:textures/entity/goats/buck_nigerian.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderBuckNigerianDwarf(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderBuckPygmy.java
+++ b/src/main/java/com/animania/client/render/goats/RenderBuckPygmy.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.ModelBullAngus;
@@ -26,7 +24,6 @@ public class RenderBuckPygmy<T extends EntityBuckPygmy> extends RenderLiving<T>
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation goatTextures = new ResourceLocation("animania:textures/entity/goats/buck_pygmy.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderBuckPygmy(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderDoeAlpine.java
+++ b/src/main/java/com/animania/client/render/goats/RenderDoeAlpine.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelDoeAlpine;
@@ -24,7 +22,6 @@ public class RenderDoeAlpine<T extends EntityDoeAlpine> extends RenderLiving<T>
 	public static final Factory           FACTORY          = new Factory();
 	private static final ResourceLocation goatTextures      = new ResourceLocation("animania:textures/entity/goats/doe_alpine.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random                                rand             = new Random();
 
 	public RenderDoeAlpine(RenderManager rm) {
 		super(rm, new ModelDoeAlpine(), 0.5F);

--- a/src/main/java/com/animania/client/render/goats/RenderDoeAngora.java
+++ b/src/main/java/com/animania/client/render/goats/RenderDoeAngora.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelDoeAngora;
@@ -26,7 +24,6 @@ public class RenderDoeAngora<T extends EntityDoeAngora> extends RenderLiving<T>
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/angora_blink.png");
 	private static final ResourceLocation goatTexturesSheared = new ResourceLocation("animania:textures/entity/goats/buck_angora_sheared.png");
 	private static final ResourceLocation goatTexturesShearedBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderDoeAngora(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderDoeFainting.java
+++ b/src/main/java/com/animania/client/render/goats/RenderDoeFainting.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelDoeFainting;
@@ -24,7 +22,6 @@ public class RenderDoeFainting<T extends EntityDoeFainting> extends RenderLiving
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation goatTextures = new ResourceLocation("animania:textures/entity/goats/doe_fainting.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderDoeFainting(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderDoeKiko.java
+++ b/src/main/java/com/animania/client/render/goats/RenderDoeKiko.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelDoeKiko;
@@ -24,7 +22,6 @@ public class RenderDoeKiko<T extends EntityDoeKiko> extends RenderLiving<T>
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation goatTextures = new ResourceLocation("animania:textures/entity/goats/doe_kiko.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderDoeKiko(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderDoeKinder.java
+++ b/src/main/java/com/animania/client/render/goats/RenderDoeKinder.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelDoeKinder;
@@ -24,7 +22,6 @@ public class RenderDoeKinder<T extends EntityDoeKinder> extends RenderLiving<T>
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation goatTextures = new ResourceLocation("animania:textures/entity/goats/doe_kinder.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderDoeKinder(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderDoeNigerianDwarf.java
+++ b/src/main/java/com/animania/client/render/goats/RenderDoeNigerianDwarf.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelDoeNigerianDwarf;
@@ -24,7 +22,6 @@ public class RenderDoeNigerianDwarf<T extends EntityDoeNigerianDwarf> extends Re
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation goatTextures = new ResourceLocation("animania:textures/entity/goats/doe_nigerian.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderDoeNigerianDwarf(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderDoePygmy.java
+++ b/src/main/java/com/animania/client/render/goats/RenderDoePygmy.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelDoePygmy;
@@ -24,7 +22,6 @@ public class RenderDoePygmy<T extends EntityDoePygmy> extends RenderLiving<T>
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation goatTextures = new ResourceLocation("animania:textures/entity/goats/doe_pygmy.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderDoePygmy(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderKidAlpine.java
+++ b/src/main/java/com/animania/client/render/goats/RenderKidAlpine.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelKidAlpine;
@@ -24,7 +22,6 @@ public class RenderKidAlpine<T extends EntityKidAlpine> extends RenderLiving<T>
 	public static final Factory           FACTORY          = new Factory();
 	private static final ResourceLocation goatTextures      = new ResourceLocation("animania:textures/entity/goats/kid_alpine.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random                                rand             = new Random();
 
 	public RenderKidAlpine(RenderManager rm) {
 		super(rm, new ModelKidAlpine(), 0.2F);

--- a/src/main/java/com/animania/client/render/goats/RenderKidAngora.java
+++ b/src/main/java/com/animania/client/render/goats/RenderKidAngora.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelKidAngora;
@@ -24,7 +22,6 @@ public class RenderKidAngora<T extends EntityKidAngora> extends RenderLiving<T>
 	public static final Factory           FACTORY          = new Factory();
 	private static final ResourceLocation goatTextures      = new ResourceLocation("animania:textures/entity/goats/kid_angora.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/angora_blink.png");
-	Random                                rand             = new Random();
 
 	public RenderKidAngora(RenderManager rm) {
 		super(rm, new ModelKidAngora(), 0.2F);

--- a/src/main/java/com/animania/client/render/goats/RenderKidFainting.java
+++ b/src/main/java/com/animania/client/render/goats/RenderKidFainting.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelKidFainting;
@@ -24,7 +22,6 @@ public class RenderKidFainting<T extends EntityKidFainting> extends RenderLiving
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation goatTextures = new ResourceLocation("animania:textures/entity/goats/kid_fainting.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderKidFainting(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderKidKiko.java
+++ b/src/main/java/com/animania/client/render/goats/RenderKidKiko.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelKidKiko;
@@ -24,7 +22,6 @@ public class RenderKidKiko<T extends EntityKidKiko> extends RenderLiving<T>
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation goatTextures = new ResourceLocation("animania:textures/entity/goats/kid_kiko.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderKidKiko(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderKidKinder.java
+++ b/src/main/java/com/animania/client/render/goats/RenderKidKinder.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelKidKinder;
@@ -24,7 +22,6 @@ public class RenderKidKinder<T extends EntityKidKinder> extends RenderLiving<T>
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation goatTextures = new ResourceLocation("animania:textures/entity/goats/kid_kinder.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderKidKinder(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderKidNigerianDwarf.java
+++ b/src/main/java/com/animania/client/render/goats/RenderKidNigerianDwarf.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelKidNigerianDwarf;
@@ -24,7 +22,6 @@ public class RenderKidNigerianDwarf<T extends EntityKidNigerianDwarf> extends Re
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation goatTextures = new ResourceLocation("animania:textures/entity/goats/kid_nigerian.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderKidNigerianDwarf(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/goats/RenderKidPygmy.java
+++ b/src/main/java/com/animania/client/render/goats/RenderKidPygmy.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.goats;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.goats.ModelKidPygmy;
@@ -24,7 +22,6 @@ public class RenderKidPygmy<T extends EntityKidPygmy> extends RenderLiving<T>
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation goatTextures = new ResourceLocation("animania:textures/entity/goats/kid_pygmy.png");
 	private static final ResourceLocation goatTexturesBlink = new ResourceLocation("animania:textures/entity/goats/goats_blink.png");
-	Random rand = new Random();
 
 	public RenderKidPygmy(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/pigs/RenderHogDuroc.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderHogDuroc.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelHog;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudHogDuroc;
@@ -72,7 +71,6 @@ public class RenderHogDuroc<T extends EntityHogDuroc> extends RenderLiving<T>
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -118,7 +116,7 @@ public class RenderHogDuroc<T extends EntityHogDuroc> extends RenderLiving<T>
 				this.shadowSize = 0.5F;
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderHogHampshire.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderHogHampshire.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelHogHampshire;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudHogHampshire;
@@ -72,7 +71,6 @@ public class RenderHogHampshire<T extends EntityHogHampshire> extends RenderLivi
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -118,7 +116,7 @@ public class RenderHogHampshire<T extends EntityHogHampshire> extends RenderLivi
 				this.shadowSize = 0.5F;
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderHogLargeBlack.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderHogLargeBlack.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelHogLargeBlack;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudHogLargeBlack;
@@ -72,7 +71,6 @@ public class RenderHogLargeBlack<T extends EntityHogLargeBlack> extends RenderLi
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -118,7 +116,7 @@ public class RenderHogLargeBlack<T extends EntityHogLargeBlack> extends RenderLi
 				this.shadowSize = 0.5F;
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderHogLargeWhite.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderHogLargeWhite.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelHog;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudHogLargeWhite;
@@ -72,7 +71,6 @@ public class RenderHogLargeWhite<T extends EntityHogLargeWhite> extends RenderLi
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -118,7 +116,7 @@ public class RenderHogLargeWhite<T extends EntityHogLargeWhite> extends RenderLi
 				this.shadowSize = 0.5F;
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderHogOldSpot.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderHogOldSpot.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelHog;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudHogOldSpot;
@@ -72,7 +71,6 @@ public class RenderHogOldSpot<T extends EntityHogOldSpot> extends RenderLiving<T
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -118,7 +116,7 @@ public class RenderHogOldSpot<T extends EntityHogOldSpot> extends RenderLiving<T
 				this.shadowSize = 0.5F;
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderHogYorkshire.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderHogYorkshire.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelHog;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudHogYorkshire;
@@ -72,7 +71,6 @@ public class RenderHogYorkshire<T extends EntityHogYorkshire> extends RenderLivi
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -118,7 +116,7 @@ public class RenderHogYorkshire<T extends EntityHogYorkshire> extends RenderLivi
 				this.shadowSize = 0.5F;
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderPigletDuroc.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderPigletDuroc.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelPiglet;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudPigletDuroc;
@@ -73,7 +72,6 @@ public class RenderPigletDuroc<T extends EntityPigletDuroc> extends RenderLiving
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -117,7 +115,7 @@ public class RenderPigletDuroc<T extends EntityPigletDuroc> extends RenderLiving
 			{
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderPigletHampshire.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderPigletHampshire.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelPigletHampshire;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.RenderSowYorkshire.Factory;
@@ -78,7 +77,6 @@ public class RenderPigletHampshire<T extends EntityPigletHampshire> extends Rend
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -122,7 +120,7 @@ public class RenderPigletHampshire<T extends EntityPigletHampshire> extends Rend
 			{
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderPigletLargeBlack.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderPigletLargeBlack.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelPiglet;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudPigletLargeBlack;
@@ -74,7 +73,6 @@ public class RenderPigletLargeBlack<T extends EntityPigletLargeBlack> extends Re
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -118,7 +116,7 @@ public class RenderPigletLargeBlack<T extends EntityPigletLargeBlack> extends Re
 			{
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderPigletLargeWhite.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderPigletLargeWhite.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelPiglet;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudPigletLargeWhite;
@@ -74,7 +73,6 @@ public class RenderPigletLargeWhite<T extends EntityPigletLargeWhite> extends Re
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -118,7 +116,7 @@ public class RenderPigletLargeWhite<T extends EntityPigletLargeWhite> extends Re
 			{
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderPigletOldSpot.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderPigletOldSpot.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelPiglet;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudPigletOldSpot;
@@ -73,7 +72,6 @@ public class RenderPigletOldSpot<T extends EntityPigletOldSpot> extends RenderLi
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -117,7 +115,7 @@ public class RenderPigletOldSpot<T extends EntityPigletOldSpot> extends RenderLi
 			{
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderPigletYorkshire.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderPigletYorkshire.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelPiglet;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudPigletYorkshire;
@@ -75,7 +74,6 @@ public class RenderPigletYorkshire<T extends EntityPigletYorkshire> extends Rend
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -119,7 +117,7 @@ public class RenderPigletYorkshire<T extends EntityPigletYorkshire> extends Rend
 			{
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderSowDuroc.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderSowDuroc.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelSow;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudSowDuroc;
@@ -73,7 +72,6 @@ public class RenderSowDuroc<T extends EntitySowDuroc> extends RenderLiving<T>
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -119,7 +117,7 @@ public class RenderSowDuroc<T extends EntitySowDuroc> extends RenderLiving<T>
 				this.shadowSize = 0.5F;
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderSowHampshire.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderSowHampshire.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelSowHampshire;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudSowHampshire;
@@ -73,7 +72,6 @@ public class RenderSowHampshire<T extends EntitySowHampshire> extends RenderLivi
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -119,7 +117,7 @@ public class RenderSowHampshire<T extends EntitySowHampshire> extends RenderLivi
 				this.shadowSize = 0.5F;
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderSowLargeBlack.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderSowLargeBlack.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelSowLargeBlack;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudSowLargeBlack;
@@ -73,7 +72,6 @@ public class RenderSowLargeBlack<T extends EntitySowLargeBlack> extends RenderLi
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -119,7 +117,7 @@ public class RenderSowLargeBlack<T extends EntitySowLargeBlack> extends RenderLi
 				this.shadowSize = 0.5F;
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderSowLargeWhite.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderSowLargeWhite.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelSow;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudSowLargeWhite;
@@ -73,7 +72,6 @@ public class RenderSowLargeWhite<T extends EntitySowLargeWhite> extends RenderLi
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -119,7 +117,7 @@ public class RenderSowLargeWhite<T extends EntitySowLargeWhite> extends RenderLi
 				this.shadowSize = 0.5F;
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderSowOldSpot.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderSowOldSpot.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelSow;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudSowOldSpot;
@@ -73,7 +72,6 @@ public class RenderSowOldSpot<T extends EntitySowOldSpot> extends RenderLiving<T
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -119,7 +117,7 @@ public class RenderSowOldSpot<T extends EntitySowOldSpot> extends RenderLiving<T
 				this.shadowSize = 0.5F;
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/pigs/RenderSowYorkshire.java
+++ b/src/main/java/com/animania/client/render/pigs/RenderSowYorkshire.java
@@ -1,9 +1,8 @@
 package com.animania.client.render.pigs;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
+import com.animania.Animania;
 import com.animania.client.models.ModelSow;
 import com.animania.client.render.layer.LayerBlinking;
 import com.animania.client.render.pigs.layers.LayerMudSowYorkshire;
@@ -73,7 +72,6 @@ public class RenderSowYorkshire<T extends EntitySowYorkshire> extends RenderLivi
 			double z = entity.posZ;
 
 			BlockPos pos = new BlockPos(x, y, z);
-			Random rand = new Random();
 
 			Block blockchk = entity.world.getBlockState(pos).getBlock();
 			Block blockchk2 = entity.world.getBlockState(pos).getBlock();
@@ -119,7 +117,7 @@ public class RenderSowYorkshire<T extends EntitySowYorkshire> extends RenderLivi
 				this.shadowSize = 0.5F;
 				entity.setMuddy(false);
 				float mudTimer = entity.getMudTimer();
-				if (rand.nextInt(3) < 1)
+				if (Animania.RANDOM.nextInt(3) < 1)
 				{
 					mudTimer = mudTimer - 0.0025F;
 					entity.setMudTimer(mudTimer);

--- a/src/main/java/com/animania/client/render/props/RenderWagon.java
+++ b/src/main/java/com/animania/client/render/props/RenderWagon.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.props;
 
-import java.util.Random;
-
 import com.animania.Animania;
 import com.animania.common.entities.props.EntityWagon;
 import com.leviathanstudio.craftstudio.client.model.ModelCraftStudio;
@@ -24,7 +22,6 @@ public class RenderWagon extends Render<EntityWagon>
 	public RenderWagon(RenderManager manager) {
 		super(manager);
 		this.shadowSize = 1.5F;
-		Random rand = new Random();
 	}
 
 	public void doRender(EntityWagon entity, double x, double y, double z, float entityYaw, float partialTicks)
@@ -62,13 +59,12 @@ public class RenderWagon extends Render<EntityWagon>
 	@Override
 	protected ResourceLocation getEntityTexture(EntityWagon entity) {
 		int blinkTimer = entity.blinkTimer;
-		Random rand = new Random();
 		
 		if (entity.world.getWorldTime() % 24000 < 13000) {
 			lastTexture = 1;
 			return this.getWagonTextures1(entity);
 		} else if (blinkTimer == 15) {
-			int bob = rand.nextInt(3);
+			int bob = Animania.RANDOM.nextInt(3);
 			if (bob == 0) {
 				lastTexture = 1;
 				return this.getWagonTextures1(entity);

--- a/src/main/java/com/animania/client/render/rabbits/RenderBuckChinchilla.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderBuckChinchilla.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelChinchilla;
@@ -27,7 +25,6 @@ public class RenderBuckChinchilla<T extends EntityRabbitBuckChinchilla> extends 
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_chinchilla.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
 	private static final ResourceLocation killerRabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_killer.png");
-	Random rand = new Random();
 
 	public RenderBuckChinchilla(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderBuckCottontail.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderBuckCottontail.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelCottontail;
@@ -27,7 +25,6 @@ public class RenderBuckCottontail<T extends EntityRabbitBuckCottontail> extends 
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_cottontail.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
 	private static final ResourceLocation killerRabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_killer.png");
-	Random rand = new Random();
 
 	public RenderBuckCottontail(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderBuckDutch.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderBuckDutch.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelDutch;
@@ -27,7 +25,6 @@ public class RenderBuckDutch<T extends EntityRabbitBuckDutch> extends RenderLivi
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_dutch.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
 	private static final ResourceLocation killerRabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_killer.png");
-	Random rand = new Random();
 
 	public RenderBuckDutch(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderBuckHavana.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderBuckHavana.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelHavana;
@@ -27,7 +25,6 @@ public class RenderBuckHavana<T extends EntityRabbitBuckHavana> extends RenderLi
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_havana.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
 	private static final ResourceLocation killerRabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_killer.png");
-	Random rand = new Random();
 
 	public RenderBuckHavana(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderBuckJack.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderBuckJack.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelJack;
@@ -27,7 +25,6 @@ public class RenderBuckJack<T extends EntityRabbitBuckJack> extends RenderLiving
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_jack.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
 	private static final ResourceLocation killerRabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_killer.png");
-	Random rand = new Random();
 
 	public RenderBuckJack(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderBuckNewZealand.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderBuckNewZealand.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelNewZealand;
@@ -27,7 +25,6 @@ public class RenderBuckNewZealand<T extends EntityRabbitBuckNewZealand> extends 
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_new_zealand.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
 	private static final ResourceLocation killerRabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_killer.png");
-	Random rand = new Random();
 
 	public RenderBuckNewZealand(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderBuckRex.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderBuckRex.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelRex;
@@ -26,7 +24,6 @@ public class RenderBuckRex<T extends EntityRabbitBuckRex> extends RenderLiving<T
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_rex.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
-	Random rand = new Random();
 
 	public RenderBuckRex(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderDoeChinchilla.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderDoeChinchilla.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelChinchilla;
@@ -27,7 +25,6 @@ public class RenderDoeChinchilla<T extends EntityRabbitDoeChinchilla> extends Re
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_chinchilla.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
 	private static final ResourceLocation killerRabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_killer.png");
-	Random rand = new Random();
 
 	public RenderDoeChinchilla(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderDoeCottontail.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderDoeCottontail.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelCottontail;
@@ -27,7 +25,6 @@ public class RenderDoeCottontail<T extends EntityRabbitDoeCottontail> extends Re
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_cottontail.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
 	private static final ResourceLocation killerRabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_killer.png");
-	Random rand = new Random();
 
 	public RenderDoeCottontail(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderDoeDutch.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderDoeDutch.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelDutch;
@@ -27,7 +25,6 @@ public class RenderDoeDutch<T extends EntityRabbitDoeDutch> extends RenderLiving
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_dutch.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
 	private static final ResourceLocation killerRabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_killer.png");
-	Random rand = new Random();
 
 	public RenderDoeDutch(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderDoeHavana.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderDoeHavana.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelHavana;
@@ -27,7 +25,6 @@ public class RenderDoeHavana<T extends EntityRabbitDoeHavana> extends RenderLivi
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_havana.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
 	private static final ResourceLocation killerRabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_killer.png");
-	Random rand = new Random();
 
 	public RenderDoeHavana(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderDoeJack.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderDoeJack.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelJack;
@@ -27,7 +25,6 @@ public class RenderDoeJack<T extends EntityRabbitDoeJack> extends RenderLiving<T
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_jack.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
 	private static final ResourceLocation killerRabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_killer.png");
-	Random rand = new Random();
 
 	public RenderDoeJack(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderDoeNewZealand.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderDoeNewZealand.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelNewZealand;
@@ -28,8 +26,6 @@ public class RenderDoeNewZealand<T extends EntityRabbitDoeNewZealand> extends Re
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
 	private static final ResourceLocation killerRabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_killer.png");
 	
-	Random rand = new Random();
-
 	public RenderDoeNewZealand(RenderManager rm)
 	{
 		super(rm, new ModelNewZealand(), 0.25F);

--- a/src/main/java/com/animania/client/render/rabbits/RenderDoeRex.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderDoeRex.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelRex;
@@ -27,7 +25,6 @@ public class RenderDoeRex<T extends EntityRabbitDoeRex> extends RenderLiving<T>
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_rex.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
 	private static final ResourceLocation killerRabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_killer.png");
-	Random rand = new Random();
 
 	public RenderDoeRex(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderKitChinchilla.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderKitChinchilla.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelChinchilla;
@@ -26,7 +24,6 @@ public class RenderKitChinchilla<T extends EntityRabbitKitChinchilla> extends Re
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_chinchilla.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
-	Random rand = new Random();
 
 	public RenderKitChinchilla(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderKitCottontail.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderKitCottontail.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelCottontail;
@@ -26,7 +24,6 @@ public class RenderKitCottontail<T extends EntityRabbitKitCottontail> extends Re
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_cottontail.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
-	Random rand = new Random();
 
 	public RenderKitCottontail(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderKitDutch.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderKitDutch.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelDutch;
@@ -26,7 +24,6 @@ public class RenderKitDutch<T extends EntityRabbitKitDutch> extends RenderLiving
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_dutch.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
-	Random rand = new Random();
 
 	public RenderKitDutch(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderKitHavana.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderKitHavana.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelHavana;
@@ -26,7 +24,6 @@ public class RenderKitHavana<T extends EntityRabbitKitHavana> extends RenderLivi
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_havana.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
-	Random rand = new Random();
 
 	public RenderKitHavana(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderKitJack.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderKitJack.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelJack;
@@ -26,7 +24,6 @@ public class RenderKitJack<T extends EntityRabbitKitJack> extends RenderLiving<T
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_jack.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
-	Random rand = new Random();
 
 	public RenderKitJack(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderKitLop.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderKitLop.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelLop;

--- a/src/main/java/com/animania/client/render/rabbits/RenderKitNewZealand.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderKitNewZealand.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelNewZealand;
@@ -26,7 +24,6 @@ public class RenderKitNewZealand<T extends EntityRabbitKitNewZealand> extends Re
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_new_zealand.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
-	Random rand = new Random();
 
 	public RenderKitNewZealand(RenderManager rm)
 	{

--- a/src/main/java/com/animania/client/render/rabbits/RenderKitRex.java
+++ b/src/main/java/com/animania/client/render/rabbits/RenderKitRex.java
@@ -1,7 +1,5 @@
 package com.animania.client.render.rabbits;
 
-import java.util.Random;
-
 import org.lwjgl.opengl.GL11;
 
 import com.animania.client.models.rabbits.ModelRex;
@@ -26,7 +24,6 @@ public class RenderKitRex<T extends EntityRabbitKitRex> extends RenderLiving<T>
 	public static final Factory FACTORY = new Factory();
 	private static final ResourceLocation rabbitTextures = new ResourceLocation("animania:textures/entity/rabbits/rabbit_rex.png");
 	private static final ResourceLocation rabbitTexturesBlink = new ResourceLocation("animania:textures/entity/rabbits/rabbit_blink.png");
-	Random rand = new Random();
 
 	public RenderKitRex(RenderManager rm)
 	{

--- a/src/main/java/com/animania/common/blocks/BlockHamsterWheel.java
+++ b/src/main/java/com/animania/common/blocks/BlockHamsterWheel.java
@@ -1,7 +1,5 @@
 package com.animania.common.blocks;
 
-import java.util.Random;
-
 import com.animania.Animania;
 import com.animania.common.capabilities.CapabilityRefs;
 import com.animania.common.capabilities.ICapabilityPlayer;
@@ -115,8 +113,7 @@ public class BlockHamsterWheel extends BlockContainer implements TOPInfoProvider
 						cap.setCarrying(false);
 						cap.setType("");
 						player.swingArm(EnumHand.MAIN_HAND);
-						Random rand = new Random();
-						player.playSound(SoundEvents.ENTITY_ITEM_PICKUP, 1.0F, (rand.nextFloat() - rand.nextFloat()) * 0.2F + 1.0F);
+						player.playSound(SoundEvents.ENTITY_ITEM_PICKUP, 1.0F, (Animania.RANDOM.nextFloat() - Animania.RANDOM.nextFloat()) * 0.2F + 1.0F);
 
 						return true;
 					}

--- a/src/main/java/com/animania/common/blocks/BlockSeeds.java
+++ b/src/main/java/com/animania/common/blocks/BlockSeeds.java
@@ -91,15 +91,13 @@ public class BlockSeeds extends Block
 	public IBlockState onBlockPlaced(World worldIn, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer)
 	{
 
-		Random rand = new Random();
-
 		for (int i = 0; i < 10; i++)
 		{
 			double d0 = pos.getX() + 0.25D;
-			double d1 = pos.getY() + rand.nextDouble() * 6.0D / 16.0D;
+			double d1 = pos.getY() + Animania.RANDOM.nextDouble() * 6.0D / 16.0D;
 			double d2 = pos.getZ() + 0.25D;
 			double d3 = 0.52D;
-			double d4 = rand.nextDouble() * 0.6D - 0.3D;
+			double d4 = Animania.RANDOM.nextDouble() * 0.6D - 0.3D;
 			worldIn.spawnParticle(EnumParticleTypes.BLOCK_CRACK, d0, d1 + .75D, d2 + d4, 0.0D, 0.0D, 0.0D, new int[] { Block.getStateId(BlockHandler.blockSeeds.getDefaultState()) });
 
 		}

--- a/src/main/java/com/animania/common/blocks/BlockStraw.java
+++ b/src/main/java/com/animania/common/blocks/BlockStraw.java
@@ -103,15 +103,13 @@ public class BlockStraw extends Block
 	public IBlockState onBlockPlaced(World worldIn, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer)
 	{
 
-		Random rand = new Random();
-
 		for (int i = 0; i < 10; i++)
 		{
 			double d0 = pos.getX() + 0.25D;
-			double d1 = pos.getY() + rand.nextDouble() * 6.0D / 16.0D;
+			double d1 = pos.getY() + Animania.RANDOM.nextDouble() * 6.0D / 16.0D;
 			double d2 = pos.getZ() + 0.25D;
 			double d3 = 0.52D;
-			double d4 = rand.nextDouble() * 0.6D - 0.3D;
+			double d4 = Animania.RANDOM.nextDouble() * 0.6D - 0.3D;
 			worldIn.spawnParticle(EnumParticleTypes.BLOCK_CRACK, d0, d1 + .75D, d2 + d4, 0.0D, 0.0D, 0.0D, new int[] { Block.getStateId(BlockHandler.blockSeeds.getDefaultState()) });
 
 		}

--- a/src/main/java/com/animania/common/blocks/BlockTrough.java
+++ b/src/main/java/com/animania/common/blocks/BlockTrough.java
@@ -356,7 +356,6 @@ public class BlockTrough extends BlockContainer implements TOPInfoProvider
 		{
 			InventoryHelper.spawnItemStack(worldIn, pos.getX(), pos.getY(), pos.getZ(), te.itemHandler.getStackInSlot(0));
 		}
-		Random rand = new Random();
 
 		super.breakBlock(worldIn, pos, state);
 	}

--- a/src/main/java/com/animania/common/blocks/BlockWildHive.java
+++ b/src/main/java/com/animania/common/blocks/BlockWildHive.java
@@ -1,7 +1,6 @@
 package com.animania.common.blocks;
 
 import java.util.List;
-import java.util.Random;
 
 import com.animania.Animania;
 import com.animania.common.handler.BlockHandler;

--- a/src/main/java/com/animania/common/entities/EntityGender.java
+++ b/src/main/java/com/animania/common/entities/EntityGender.java
@@ -1,8 +1,9 @@
 package com.animania.common.entities;
 
+import com.animania.Animania;
+
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.world.World;
-import scala.util.Random;
 
 public enum EntityGender
 {
@@ -20,8 +21,7 @@ public enum EntityGender
 		case CHILD:
 			return type.getChild(world);
 		case RANDOM:
-			Random rand = new Random();
-			switch(rand.nextInt(3))
+			switch(Animania.RANDOM.nextInt(3))
 			{
 			case 0:
 				return type.getMale(world);

--- a/src/main/java/com/animania/common/entities/RandomAnimalType.java
+++ b/src/main/java/com/animania/common/entities/RandomAnimalType.java
@@ -1,8 +1,9 @@
 package com.animania.common.entities;
 
 import java.util.HashSet;
-import java.util.Random;
 import java.util.Set;
+
+import com.animania.Animania;
 
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.world.World;
@@ -20,18 +21,16 @@ public class RandomAnimalType implements AnimaniaType
 	@Override
 	public EntityLivingBase getMale(World world)
 	{
-		Random rand = new Random();
-
-		Class<? extends AnimaniaType> type = types.toArray(new Class[types.size()])[rand.nextInt(types.size())];
+		Class<? extends AnimaniaType> type = types.toArray(new Class[types.size()])[Animania.RANDOM.nextInt(types.size())];
 		AnimaniaType[] breeds = type.getEnumConstants();
 
 		EntityLivingBase entity = null;
 		while (entity == null)
 		{
-			entity = breeds[rand.nextInt(breeds.length)].getMale(world);
+			entity = breeds[Animania.RANDOM.nextInt(breeds.length)].getMale(world);
 			if (entity == null)
 			{
-				type = types.toArray(new Class[types.size()])[rand.nextInt(types.size())];
+				type = types.toArray(new Class[types.size()])[Animania.RANDOM.nextInt(types.size())];
 				breeds = type.getEnumConstants();
 			}
 		}
@@ -43,18 +42,16 @@ public class RandomAnimalType implements AnimaniaType
 	@Override
 	public EntityLivingBase getFemale(World world)
 	{
-		Random rand = new Random();
-
-		Class<? extends AnimaniaType> type = types.toArray(new Class[types.size()])[rand.nextInt(types.size())];
+		Class<? extends AnimaniaType> type = types.toArray(new Class[types.size()])[Animania.RANDOM.nextInt(types.size())];
 		AnimaniaType[] breeds = type.getEnumConstants();
 
 		EntityLivingBase entity = null;
 		while (entity == null)
 		{
-			entity = breeds[rand.nextInt(breeds.length)].getFemale(world);
+			entity = breeds[Animania.RANDOM.nextInt(breeds.length)].getFemale(world);
 			if (entity == null)
 			{
-				type = types.toArray(new Class[types.size()])[rand.nextInt(types.size())];
+				type = types.toArray(new Class[types.size()])[Animania.RANDOM.nextInt(types.size())];
 				breeds = type.getEnumConstants();
 			}
 		}
@@ -65,18 +62,16 @@ public class RandomAnimalType implements AnimaniaType
 	@Override
 	public EntityLivingBase getChild(World world)
 	{
-		Random rand = new Random();
-
-		Class<? extends AnimaniaType> type = types.toArray(new Class[types.size()])[rand.nextInt(types.size())];
+		Class<? extends AnimaniaType> type = types.toArray(new Class[types.size()])[Animania.RANDOM.nextInt(types.size())];
 		AnimaniaType[] breeds = type.getEnumConstants();
 
 		EntityLivingBase entity = null;
 		while (entity == null)
 		{
-			entity = breeds[rand.nextInt(breeds.length)].getChild(world);
+			entity = breeds[Animania.RANDOM.nextInt(breeds.length)].getChild(world);
 			if (entity == null)
 			{
-				type = types.toArray(new Class[types.size()])[rand.nextInt(types.size())];
+				type = types.toArray(new Class[types.size()])[Animania.RANDOM.nextInt(types.size())];
 				breeds = type.getEnumConstants();
 			}
 		}

--- a/src/main/java/com/animania/common/entities/amphibians/EntityAmphibian.java
+++ b/src/main/java/com/animania/common/entities/amphibians/EntityAmphibian.java
@@ -1,7 +1,5 @@
 package com.animania.common.entities.amphibians;
 
-import java.util.Random;
-
 import net.minecraft.entity.EntityAgeable;
 import net.minecraft.entity.IEntityLivingData;
 import net.minecraft.entity.SharedMonsterAttributes;
@@ -31,6 +29,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.chickens.EntityAnimaniaChicken;
 import com.animania.common.entities.interfaces.IAnimaniaAnimal;
@@ -426,8 +425,7 @@ public class EntityAmphibian extends EntityAnimal implements ISpawnable, IAniman
 			super.setMoveTo(x, y, z, speedIn);
 
 			if (speedIn > 0.0D) {
-				Random rand = new Random();
-				float distance = rand.nextFloat() / 25;
+				float distance = Animania.RANDOM.nextFloat() / 25;
 				this.nextJumpSpeed = speedIn + distance;
 			}
 		}

--- a/src/main/java/com/animania/common/entities/amphibians/EntityDartFrogs.java
+++ b/src/main/java/com/animania/common/entities/amphibians/EntityDartFrogs.java
@@ -1,7 +1,5 @@
 package com.animania.common.entities.amphibians;
 
-import java.util.Random;
-
 import javax.annotation.Nullable;
 
 import com.animania.Animania;
@@ -175,8 +173,7 @@ public class EntityDartFrogs extends EntityAmphibian
 	@Override
 	protected SoundEvent getAmbientSound() {
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(5);
+		int chooser = Animania.RANDOM.nextInt(5);
 
 		if (chooser == 0)
 			return ModSoundEvents.dartfrogLiving1;

--- a/src/main/java/com/animania/common/entities/amphibians/EntityFrogs.java
+++ b/src/main/java/com/animania/common/entities/amphibians/EntityFrogs.java
@@ -2,7 +2,6 @@ package com.animania.common.entities.amphibians;
 
 import java.util.Calendar;
 import java.util.List;
-import java.util.Random;
 
 import javax.annotation.Nullable;
 
@@ -181,16 +180,14 @@ public class EntityFrogs extends EntityAmphibian
 	@Override
 	protected SoundEvent getAmbientSound()
 	{
-
-		Random rand = new Random();
-		int chooser = rand.nextInt(4);
-		if (this.getCustomNameTag().equals("Pepe") && 0.1 > Math.random())
+		int chooser = Animania.RANDOM.nextInt(4);
+		if (this.getCustomNameTag().equals("Pepe") && 0.1 > Animania.RANDOM.nextDouble())
 		{
 			this.addPotionEffect(new PotionEffect(MobEffects.SPEED, 5, 4, true, false));
 			return ModSoundEvents.reeee;
 		}
 		
-		if(Math.random() < 0.3 &&  this.getCustomNameTag().equalsIgnoreCase("me_irl") && Calendar.getInstance().get(Calendar.DAY_OF_WEEK) == Calendar.WEDNESDAY)
+		if(Animania.RANDOM.nextDouble() < 0.3 &&  this.getCustomNameTag().equalsIgnoreCase("me_irl") && Calendar.getInstance().get(Calendar.DAY_OF_WEEK) == Calendar.WEDNESDAY)
 		{
 			return ModSoundEvents.oooohhh;
 		}

--- a/src/main/java/com/animania/common/entities/amphibians/EntityToad.java
+++ b/src/main/java/com/animania/common/entities/amphibians/EntityToad.java
@@ -1,7 +1,5 @@
 package com.animania.common.entities.amphibians;
 
-import java.util.Random;
-
 import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.AnimalContainer;
@@ -32,8 +30,7 @@ public class EntityToad extends EntityAmphibian
 	@Override
 	protected SoundEvent getAmbientSound() {
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(5);
+		int chooser = Animania.RANDOM.nextInt(5);
 
 		if (chooser == 0)
 			return ModSoundEvents.toadLiving1;

--- a/src/main/java/com/animania/common/entities/chickens/ChickenType.java
+++ b/src/main/java/com/animania/common/entities/chickens/ChickenType.java
@@ -2,8 +2,8 @@ package com.animania.common.entities.chickens;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Random;
 
+import com.animania.Animania;
 import com.animania.common.entities.AnimaniaType;
 
 import net.minecraft.world.World;
@@ -104,11 +104,7 @@ public enum ChickenType implements AnimaniaType
 
 	public static ChickenType breed(ChickenType male, ChickenType female)
 	{
-		Random rand = new Random();
-		if(rand.nextInt(2) == 0)
-			return male;
-		else
-			return female;
+		return Animania.RANDOM.nextBoolean() ? male : female;
 	}
 
 }

--- a/src/main/java/com/animania/common/entities/chickens/EntityAnimaniaChicken.java
+++ b/src/main/java/com/animania/common/entities/chickens/EntityAnimaniaChicken.java
@@ -1,6 +1,5 @@
 package com.animania.common.entities.chickens;
 
-import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
@@ -436,8 +435,7 @@ public class EntityAnimaniaChicken extends EntityChicken implements IAnimaniaAni
 		else
 			num = 24;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.chickenCluck1;

--- a/src/main/java/com/animania/common/entities/chickens/EntityRoosterBase.java
+++ b/src/main/java/com/animania/common/entities/chickens/EntityRoosterBase.java
@@ -1,8 +1,8 @@
 package com.animania.common.entities.chickens;
 
 import java.util.List;
-import java.util.Random;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.amphibians.EntityAmphibian;
@@ -198,24 +198,12 @@ public class EntityRoosterBase extends EntityAnimaniaChicken implements TOPInfoP
 
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source) {
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
-
-		if (chooser == 0)
-			return ModSoundEvents.chickenHurt1;
-		else
-			return ModSoundEvents.chickenHurt2;
+		return Animania.RANDOM.nextBoolean() ? ModSoundEvents.chickenHurt1 : ModSoundEvents.chickenHurt2;
 	}
 
 	@Override
 	protected SoundEvent getDeathSound() {
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
-
-		if (chooser == 0)
-			return ModSoundEvents.chickenDeath1;
-		else
-			return ModSoundEvents.chickenDeath2;
+		return Animania.RANDOM.nextBoolean() ? ModSoundEvents.chickenDeath1 : ModSoundEvents.chickenDeath2;
 	}
 
 	@Override

--- a/src/main/java/com/animania/common/entities/cows/CowType.java
+++ b/src/main/java/com/animania/common/entities/cows/CowType.java
@@ -2,8 +2,8 @@ package com.animania.common.entities.cows;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Random;
 
+import com.animania.Animania;
 import com.animania.common.entities.AnimaniaType;
 
 import net.minecraft.world.World;
@@ -106,11 +106,7 @@ public enum CowType implements AnimaniaType
 
 	public static CowType breed(CowType male, CowType female)
 	{
-		Random rand = new Random();
-		if(rand.nextInt(2) == 0)
-			return male;
-		else
-			return female;
+		return Animania.RANDOM.nextBoolean() ? male : female;
 	}
 
 

--- a/src/main/java/com/animania/common/entities/cows/EntityBullBase.java
+++ b/src/main/java/com/animania/common/entities/cows/EntityBullBase.java
@@ -2,7 +2,6 @@ package com.animania.common.entities.cows;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -29,6 +28,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.cows.ai.EntityAIAttackMeleeBulls;
@@ -167,8 +167,7 @@ public class EntityBullBase extends EntityAnimaniaCow implements TOPInfoProvider
 		else
 			num = 60;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 		if (chooser == 0)
 			return ModSoundEvents.bullMoo1;
 		else if (chooser == 1)
@@ -198,8 +197,7 @@ public class EntityBullBase extends EntityAnimaniaCow implements TOPInfoProvider
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
+		int chooser = Animania.RANDOM.nextInt(2);
 
 		if (chooser == 0)
 			return ModSoundEvents.angryBull1;
@@ -212,13 +210,7 @@ public class EntityBullBase extends EntityAnimaniaCow implements TOPInfoProvider
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
-
-		if (chooser == 0)
-			return ModSoundEvents.cowDeath1;
-		else
-			return ModSoundEvents.cowDeath2;
+		return Animania.RANDOM.nextBoolean() ? ModSoundEvents.cowDeath1 : ModSoundEvents.cowDeath2;
 	}
 
 	@Override

--- a/src/main/java/com/animania/common/entities/cows/EntityCalfBase.java
+++ b/src/main/java/com/animania/common/entities/cows/EntityCalfBase.java
@@ -1,6 +1,5 @@
 package com.animania.common.entities.cows;
 
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -26,6 +25,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.cows.ai.EntityAIFollowParentCows;
@@ -163,8 +163,7 @@ public class EntityCalfBase extends EntityAnimaniaCow implements TOPInfoProvider
 		else
 			num = 24;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.mooCalf1;
@@ -179,8 +178,7 @@ public class EntityCalfBase extends EntityAnimaniaCow implements TOPInfoProvider
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.mooCalf1;
@@ -193,8 +191,7 @@ public class EntityCalfBase extends EntityAnimaniaCow implements TOPInfoProvider
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.mooCalf1;

--- a/src/main/java/com/animania/common/entities/cows/EntityCowBase.java
+++ b/src/main/java/com/animania/common/entities/cows/EntityCowBase.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.cows;
 
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -44,6 +43,7 @@ import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.cows.ai.EntityAIMateCows;
@@ -307,8 +307,7 @@ public class EntityCowBase extends EntityAnimaniaCow implements TOPInfoProviderM
 		else
 			num = 60;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.moo1;
@@ -334,25 +333,13 @@ public class EntityCowBase extends EntityAnimaniaCow implements TOPInfoProviderM
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
-
-		if (chooser == 0)
-			return ModSoundEvents.cowHurt1;
-		else
-			return ModSoundEvents.cowHurt2;
+		return Animania.RANDOM.nextBoolean() ? ModSoundEvents.cowHurt1 : ModSoundEvents.cowHurt2;
 	}
 
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
-
-		if (chooser == 0)
-			return ModSoundEvents.cowDeath1;
-		else
-			return ModSoundEvents.cowDeath2;
+		return Animania.RANDOM.nextBoolean() ? ModSoundEvents.cowDeath1 : ModSoundEvents.cowDeath2;
 	}
 
 	@Override

--- a/src/main/java/com/animania/common/entities/cows/ai/EntityAIFollowParentCows.java
+++ b/src/main/java/com/animania/common/entities/cows/ai/EntityAIFollowParentCows.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.cows.ai;
 
 import java.util.List;
-import java.util.Random;
 
 import com.animania.common.entities.cows.EntityAnimaniaCow;
 import com.animania.common.entities.cows.EntityCalfBase;
@@ -20,7 +19,6 @@ public class EntityAIFollowParentCows extends EntityAIBase
 	EntityAnimaniaCow parentAnimal;
 	double       moveSpeed;
 	private int  delayCounter;
-	Random       rand = new Random();
 
 	public EntityAIFollowParentCows(EntityAnimaniaCow animal, double speed) {
 		this.childAnimal = animal;

--- a/src/main/java/com/animania/common/entities/cows/ai/EntityAIMateCows.java
+++ b/src/main/java/com/animania/common/entities/cows/ai/EntityAIMateCows.java
@@ -1,9 +1,9 @@
 package com.animania.common.entities.cows.ai;
 
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
+import com.animania.Animania;
 import com.animania.common.entities.cows.EntityAnimaniaCow;
 import com.animania.common.entities.cows.EntityBullBase;
 import com.animania.common.entities.cows.EntityCalfBase;
@@ -23,7 +23,6 @@ public class EntityAIMateCows extends EntityAIBase
 	int                        courtshipTimer;
 	double                     moveSpeed;
 	private int                delayCounter;
-	private Random			   rand;
 
 	public EntityAIMateCows(EntityAnimaniaCow animal, double speedIn) {
 		this.theAnimal = animal;
@@ -32,7 +31,6 @@ public class EntityAIMateCows extends EntityAIBase
 		this.setMutexBits(3);
 		this.courtshipTimer = 20;
 		this.delayCounter = 0;
-		this.rand = new Random();
 
 	}
 
@@ -85,8 +83,7 @@ public class EntityAIMateCows extends EntityAIBase
 
 			this.targetMate = this.getNearbyMate();
 
-			Random rand = new Random();
-			if (this.targetMate != null && rand.nextInt(20) == 0) {
+			if (this.targetMate != null && Animania.RANDOM.nextInt(20) == 0) {
 				this.delayCounter = 0;
 				this.resetTask();
 				return false;

--- a/src/main/java/com/animania/common/entities/generic/ai/GenericAIFindFood_old.java
+++ b/src/main/java/com/animania/common/entities/generic/ai/GenericAIFindFood_old.java
@@ -1,9 +1,8 @@
 package com.animania.common.entities.generic.ai;
 
-import java.util.Random;
-
 import javax.annotation.Nullable;
 
+import com.animania.Animania;
 import com.animania.common.entities.interfaces.IFoodEating;
 import com.animania.common.entities.interfaces.ISleeping;
 import com.animania.common.handler.BlockHandler;
@@ -189,7 +188,6 @@ public class GenericAIFindFood_old<T extends EntityCreature & IFoodEating> exten
 			double z = this.entity.posZ;
 
 			boolean foodFound = false;
-			Random rand = new Random();
 
 			BlockPos pos = new BlockPos(x, y, z);
 
@@ -210,7 +208,7 @@ public class GenericAIFindFood_old<T extends EntityCreature & IFoodEating> exten
 							if (te != null && (te.fluidHandler.getFluid() != null && entity.getFoodFluid() != null && te.fluidHandler.getFluid().getFluid() == entity.getFoodFluid()) || te.canConsume(entity.getFoodItems(), null))
 							{
 								foodFound = true;
-								if (rand.nextInt(200) == 0)
+								if (Animania.RANDOM.nextInt(200) == 0)
 								{
 									this.foodDelay = 0;
 									return false;
@@ -233,7 +231,7 @@ public class GenericAIFindFood_old<T extends EntityCreature & IFoodEating> exten
 							{
 
 								foodFound = true;
-								if (rand.nextInt(200) == 0)
+								if (Animania.RANDOM.nextInt(200) == 0)
 								{
 									this.foodDelay = 0;
 									return false;

--- a/src/main/java/com/animania/common/entities/generic/ai/GenericAIFollowParents.java
+++ b/src/main/java/com/animania/common/entities/generic/ai/GenericAIFollowParents.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.generic.ai;
 
 import java.util.List;
-import java.util.Random;
 
 import com.animania.common.entities.interfaces.IChild;
 import com.animania.common.entities.interfaces.IMateable;
@@ -22,7 +21,6 @@ public class GenericAIFollowParents<T extends EntityCreature & IChild & ISleepin
 	O parentAnimal;
 	double moveSpeed;
 	private int delayCounter;
-	Random rand = new Random();
 	Class mother;
 
 	public GenericAIFollowParents(T animal, double speed, Class mother)

--- a/src/main/java/com/animania/common/entities/generic/ai/GenericAIMate.java
+++ b/src/main/java/com/animania/common/entities/generic/ai/GenericAIMate.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.generic.ai;
 
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import net.minecraft.entity.EntityCreature;
@@ -9,6 +8,7 @@ import net.minecraft.entity.ai.EntityAIBase;
 import net.minecraft.entity.passive.EntityAnimal;
 import net.minecraft.world.World;
 
+import com.animania.Animania;
 import com.animania.common.entities.interfaces.IFoodEating;
 import com.animania.common.entities.interfaces.IMateable;
 import com.animania.common.entities.interfaces.ISleeping;
@@ -24,7 +24,6 @@ public class GenericAIMate<T extends EntityCreature & IMateable & IFoodEating & 
 	int courtshipTimer;
 	double moveSpeed;
 	private int delayCounter;
-	private Random rand;
 
 	private Class female;
 	private Class child;
@@ -38,7 +37,6 @@ public class GenericAIMate<T extends EntityCreature & IMateable & IFoodEating & 
 		this.setMutexBits(3);
 		this.courtshipTimer = 20;
 		this.delayCounter = 0;
-		this.rand = new Random();
 		this.female = other;
 		this.child = child;
 		this.base = base;
@@ -97,8 +95,7 @@ public class GenericAIMate<T extends EntityCreature & IMateable & IFoodEating & 
 
 			this.targetMate = this.getNearbyMate();
 
-			Random rand = new Random();
-			if (this.targetMate != null && rand.nextInt(20) == 0)
+			if (this.targetMate != null && Animania.RANDOM.nextInt(20) == 0)
 			{
 				this.delayCounter = 0;
 				this.resetTask();

--- a/src/main/java/com/animania/common/entities/goats/EntityBuckBase.java
+++ b/src/main/java/com/animania/common/entities/goats/EntityBuckBase.java
@@ -2,7 +2,6 @@ package com.animania.common.entities.goats;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -32,6 +31,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.cows.EntityAnimaniaCow;
@@ -150,8 +150,7 @@ public class EntityBuckBase extends EntityAnimaniaGoat implements TOPInfoProvide
 		else
 			num = 40;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.goatLiving1;
@@ -171,8 +170,7 @@ public class EntityBuckBase extends EntityAnimaniaGoat implements TOPInfoProvide
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.goatHurt1;
@@ -185,8 +183,7 @@ public class EntityBuckBase extends EntityAnimaniaGoat implements TOPInfoProvide
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.goatHurt1;

--- a/src/main/java/com/animania/common/entities/goats/EntityDoeBase.java
+++ b/src/main/java/com/animania/common/entities/goats/EntityDoeBase.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.goats;
 
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -41,6 +40,7 @@ import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.interfaces.IMateable;
@@ -276,8 +276,7 @@ public class EntityDoeBase extends EntityAnimaniaGoat implements TOPInfoProvider
 		else
 			num = 40;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.goatLiving1;
@@ -297,8 +296,7 @@ public class EntityDoeBase extends EntityAnimaniaGoat implements TOPInfoProvider
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.goatHurt1;
@@ -311,8 +309,7 @@ public class EntityDoeBase extends EntityAnimaniaGoat implements TOPInfoProvider
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.goatHurt1;

--- a/src/main/java/com/animania/common/entities/goats/EntityKidBase.java
+++ b/src/main/java/com/animania/common/entities/goats/EntityKidBase.java
@@ -1,6 +1,5 @@
 package com.animania.common.entities.goats;
 
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -20,6 +19,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.goats.ai.EntityAIFollowParentGoats;
@@ -138,8 +138,7 @@ public class EntityKidBase extends EntityAnimaniaGoat implements TOPInfoProvider
 		else
 			num = 32;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.kidLiving1;
@@ -155,8 +154,7 @@ public class EntityKidBase extends EntityAnimaniaGoat implements TOPInfoProvider
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.kidHurt1;
@@ -169,8 +167,7 @@ public class EntityKidBase extends EntityAnimaniaGoat implements TOPInfoProvider
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.kidHurt1;

--- a/src/main/java/com/animania/common/entities/goats/GoatType.java
+++ b/src/main/java/com/animania/common/entities/goats/GoatType.java
@@ -2,8 +2,8 @@ package com.animania.common.entities.goats;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Random;
 
+import com.animania.Animania;
 import com.animania.common.entities.AnimaniaType;
 
 import net.minecraft.stats.StatBase;
@@ -109,11 +109,7 @@ public enum GoatType implements AnimaniaType
 
 	public static GoatType breed(GoatType male, GoatType female)
 	{
-		Random rand = new Random();
-		if(rand.nextInt(2) == 0)
-			return male;
-		else
-			return female;
+		return Animania.RANDOM.nextBoolean() ? male : female;
 	}
 
 	public StatBase getAchievement()

--- a/src/main/java/com/animania/common/entities/goats/ai/EntityAIButtHeadsGoats.java
+++ b/src/main/java/com/animania/common/entities/goats/ai/EntityAIButtHeadsGoats.java
@@ -1,8 +1,8 @@
 package com.animania.common.entities.goats.ai;
 
 import java.util.List;
-import java.util.Random;
 
+import com.animania.Animania;
 import com.animania.common.entities.goats.EntityAnimaniaGoat;
 import com.animania.common.entities.goats.EntityBuckBase;
 import com.animania.common.entities.goats.EntityDoeBase;
@@ -22,7 +22,6 @@ public class EntityAIButtHeadsGoats extends EntityAIBase
 	int fightTimer;
 	double moveSpeed;
 	private int delayCounter;
-	Random rand = new Random();
 
 
 	public EntityAIButtHeadsGoats(EntityAnimaniaGoat animal, double speedIn)
@@ -31,7 +30,7 @@ public class EntityAIButtHeadsGoats extends EntityAIBase
 		this.theWorld = animal.world;
 		this.moveSpeed = speedIn;
 		this.setMutexBits(3);
-		this.fightTimer = 100 + rand.nextInt(50);
+		this.fightTimer = 100 + Animania.RANDOM.nextInt(50);
 		this.delayCounter = 0;
 
 	}
@@ -53,8 +52,7 @@ public class EntityAIButtHeadsGoats extends EntityAIBase
 			
 			this.targetMate = this.getNearbyRival();
 
-			Random rand = new Random();
-			if (this.targetMate != null && rand.nextInt(20) == 0) {
+			if (this.targetMate != null && Animania.RANDOM.nextInt(20) == 0) {
 				this.delayCounter = 0;
 				this.resetTask();
 				return false;
@@ -138,7 +136,7 @@ public class EntityAIButtHeadsGoats extends EntityAIBase
 			if (foundEntity != null) {
 				
 				if (this.fightTimer < 0 && thisEntity.getFighting()) {
-					this.fightTimer = 100 + rand.nextInt(50);
+					this.fightTimer = 100 + Animania.RANDOM.nextInt(50);
 					this.targetMate = null;
 					thisEntity.setFighting(false);
 					foundEntity.setFighting(false);
@@ -161,7 +159,7 @@ public class EntityAIButtHeadsGoats extends EntityAIBase
 
 				} 
 			} else if (foundEntity == null || fightTimer < 0) {
-				this.fightTimer = 100 + rand.nextInt(50);
+				this.fightTimer = 100 + Animania.RANDOM.nextInt(50);
 				this.targetMate = null;
 				thisEntity.setFighting(false);
 				thisEntity.setRivalUniqueId(null);

--- a/src/main/java/com/animania/common/entities/goats/ai/EntityAIFollowParentGoats.java
+++ b/src/main/java/com/animania/common/entities/goats/ai/EntityAIFollowParentGoats.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.goats.ai;
 
 import java.util.List;
-import java.util.Random;
 
 import com.animania.common.entities.goats.EntityAnimaniaGoat;
 import com.animania.common.entities.goats.EntityDoeBase;
@@ -19,7 +18,6 @@ public class EntityAIFollowParentGoats extends EntityAIBase
 	EntityAnimaniaGoat parentAnimal;
 	double moveSpeed;
 	private int delayCounter;
-	Random rand = new Random();
 
 	public EntityAIFollowParentGoats(EntityAnimaniaGoat animal, double speed)
 	{

--- a/src/main/java/com/animania/common/entities/goats/ai/EntityAIMateGoats.java
+++ b/src/main/java/com/animania/common/entities/goats/ai/EntityAIMateGoats.java
@@ -1,9 +1,9 @@
 package com.animania.common.entities.goats.ai;
 
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
+import com.animania.Animania;
 import com.animania.common.entities.goats.EntityAnimaniaGoat;
 import com.animania.common.entities.goats.EntityBuckBase;
 import com.animania.common.entities.goats.EntityDoeBase;
@@ -23,7 +23,6 @@ public class EntityAIMateGoats extends EntityAIBase
 	int                        			courtshipTimer;
 	double                     			moveSpeed;
 	private int                			delayCounter;
-	private Random			   			rand;
 
 	public EntityAIMateGoats(EntityAnimaniaGoat animal, double speedIn) {
 		this.theAnimal = animal;
@@ -32,7 +31,6 @@ public class EntityAIMateGoats extends EntityAIBase
 		this.setMutexBits(3);
 		this.courtshipTimer = 20;
 		this.delayCounter = 0;
-		this.rand = new Random();
 
 	}
 
@@ -81,8 +79,7 @@ public class EntityAIMateGoats extends EntityAIBase
 
 			this.targetMate = (EntityAnimaniaGoat) this.getNearbyMate();
 
-			Random rand = new Random();
-			if (this.targetMate != null && rand.nextInt(20) == 0) {
+			if (this.targetMate != null && Animania.RANDOM.nextInt(20) == 0) {
 				this.delayCounter = 0;
 				this.resetTask();
 				return false;

--- a/src/main/java/com/animania/common/entities/horses/EntityFoalBase.java
+++ b/src/main/java/com/animania/common/entities/horses/EntityFoalBase.java
@@ -1,6 +1,5 @@
 package com.animania.common.entities.horses;
 
-import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
@@ -30,6 +29,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.horses.ai.EntityAIFollowParentHorses;
@@ -142,8 +142,7 @@ public class EntityFoalBase extends EntityAnimaniaHorse implements TOPInfoProvid
 			num = 60;
 		}
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0) {
 			return ModSoundEvents.horseliving1;
@@ -162,8 +161,7 @@ public class EntityFoalBase extends EntityAnimaniaHorse implements TOPInfoProvid
 
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0) {
 			return ModSoundEvents.horsehurt1;
@@ -176,8 +174,7 @@ public class EntityFoalBase extends EntityAnimaniaHorse implements TOPInfoProvid
 
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0) {
 			return ModSoundEvents.horsehurt1;

--- a/src/main/java/com/animania/common/entities/horses/EntityMareBase.java
+++ b/src/main/java/com/animania/common/entities/horses/EntityMareBase.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.horses;
 
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -42,6 +41,7 @@ import net.minecraftforge.event.entity.living.BabyEntitySpawnEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.interfaces.IMateable;
@@ -445,8 +445,7 @@ public class EntityMareBase extends EntityAnimaniaHorse implements TOPInfoProvid
 			num = 60;
 		}
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0) {
 			return ModSoundEvents.horseliving1;
@@ -465,8 +464,7 @@ public class EntityMareBase extends EntityAnimaniaHorse implements TOPInfoProvid
 
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0) {
 			return ModSoundEvents.horsehurt1;
@@ -479,8 +477,7 @@ public class EntityMareBase extends EntityAnimaniaHorse implements TOPInfoProvid
 
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0) {
 			return ModSoundEvents.horsehurt1;

--- a/src/main/java/com/animania/common/entities/horses/EntityStallionBase.java
+++ b/src/main/java/com/animania/common/entities/horses/EntityStallionBase.java
@@ -2,7 +2,6 @@ package com.animania.common.entities.horses;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -38,6 +37,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.cows.EntityBullBase;
@@ -246,8 +246,7 @@ public class EntityStallionBase extends EntityAnimaniaHorse implements TOPInfoPr
 			num = 60;
 		}
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 		{
@@ -272,8 +271,7 @@ public class EntityStallionBase extends EntityAnimaniaHorse implements TOPInfoPr
 
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 		{
@@ -289,8 +287,7 @@ public class EntityStallionBase extends EntityAnimaniaHorse implements TOPInfoPr
 
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 		{

--- a/src/main/java/com/animania/common/entities/horses/HorseType.java
+++ b/src/main/java/com/animania/common/entities/horses/HorseType.java
@@ -2,8 +2,8 @@ package com.animania.common.entities.horses;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Random;
 
+import com.animania.Animania;
 import com.animania.common.entities.AnimaniaType;
 
 import net.minecraft.world.World;
@@ -97,11 +97,7 @@ public enum HorseType implements AnimaniaType
 
 	public static HorseType breed(HorseType male, HorseType female)
 	{
-		Random rand = new Random();
-		if(rand.nextInt(2) == 0)
-			return male;
-		else
-			return female;
+		return Animania.RANDOM.nextBoolean() ? male : female;
 	}
 
 }

--- a/src/main/java/com/animania/common/entities/horses/ai/EntityAIFollowParentHorses.java
+++ b/src/main/java/com/animania/common/entities/horses/ai/EntityAIFollowParentHorses.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.horses.ai;
 
 import java.util.List;
-import java.util.Random;
 
 import com.animania.common.entities.horses.EntityAnimaniaHorse;
 import com.animania.common.entities.horses.EntityFoalBase;
@@ -19,7 +18,6 @@ public class EntityAIFollowParentHorses extends EntityAIBase
 	EntityAnimal parentAnimal;
 	double moveSpeed;
 	private int delayCounter;
-	Random rand = new Random();
 
 	public EntityAIFollowParentHorses(EntityAnimaniaHorse animal, double speed)
 	{

--- a/src/main/java/com/animania/common/entities/horses/ai/EntityAIMateHorses.java
+++ b/src/main/java/com/animania/common/entities/horses/ai/EntityAIMateHorses.java
@@ -1,9 +1,9 @@
 package com.animania.common.entities.horses.ai;
 
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
+import com.animania.Animania;
 import com.animania.common.entities.horses.EntityAnimaniaHorse;
 import com.animania.common.entities.horses.EntityFoalBase;
 import com.animania.common.entities.horses.EntityMareBase;
@@ -23,7 +23,6 @@ public class EntityAIMateHorses extends EntityAIBase
 	int                        courtshipTimer;
 	double                     moveSpeed;
 	private int                delayCounter;
-	private Random			   rand;
 
 	public EntityAIMateHorses(EntityAnimaniaHorse animal, double speedIn) {
 		this.theAnimal = animal;
@@ -32,7 +31,6 @@ public class EntityAIMateHorses extends EntityAIBase
 		this.setMutexBits(3);
 		this.courtshipTimer = 20;
 		this.delayCounter = 0;
-		this.rand = new Random();
 
 	}
 
@@ -85,8 +83,7 @@ public class EntityAIMateHorses extends EntityAIBase
 
 			this.targetMate = this.getNearbyMate();
 
-			Random rand = new Random();
-			if (this.targetMate != null && rand.nextInt(20) == 0) {
+			if (this.targetMate != null && Animania.RANDOM.nextInt(20) == 0) {
 				this.delayCounter = 0;
 				this.resetTask();
 				return false;

--- a/src/main/java/com/animania/common/entities/peacocks/EntityAnimaniaPeacock.java
+++ b/src/main/java/com/animania/common/entities/peacocks/EntityAnimaniaPeacock.java
@@ -1,6 +1,5 @@
 package com.animania.common.entities.peacocks;
 
-import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
@@ -574,8 +573,7 @@ public class EntityAnimaniaPeacock extends EntityAnimal implements TOPInfoProvid
 		else
 			num = 100;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.peacock1;
@@ -604,8 +602,7 @@ public class EntityAnimaniaPeacock extends EntityAnimal implements TOPInfoProvid
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
+		int chooser = Animania.RANDOM.nextInt(2);
 
 		if (chooser == 0)
 			return ModSoundEvents.peacockHurt1;
@@ -616,8 +613,7 @@ public class EntityAnimaniaPeacock extends EntityAnimal implements TOPInfoProvid
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
+		int chooser = Animania.RANDOM.nextInt(2);
 
 		if (chooser == 0)
 			return ModSoundEvents.peacockHurt1;

--- a/src/main/java/com/animania/common/entities/peacocks/PeacockType.java
+++ b/src/main/java/com/animania/common/entities/peacocks/PeacockType.java
@@ -2,8 +2,8 @@ package com.animania.common.entities.peacocks;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Random;
 
+import com.animania.Animania;
 import com.animania.common.entities.AnimaniaType;
 
 import net.minecraft.world.World;
@@ -103,11 +103,7 @@ public enum PeacockType implements AnimaniaType
 
 	public static PeacockType breed(PeacockType male, PeacockType female)
 	{
-		Random rand = new Random();
-		if(rand.nextInt(2) == 0)
-			return male;
-		else
-			return female;
+		return Animania.RANDOM.nextBoolean() ? male : female;
 	}
 
 }

--- a/src/main/java/com/animania/common/entities/pigs/EntityHogBase.java
+++ b/src/main/java/com/animania/common/entities/pigs/EntityHogBase.java
@@ -2,7 +2,6 @@ package com.animania.common.entities.pigs;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -32,6 +31,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.cows.EntityBullBase;
@@ -173,8 +173,7 @@ public class EntityHogBase extends EntityAnimaniaPig implements TOPInfoProviderP
 		else
 			num = 40;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.hog1;
@@ -200,8 +199,7 @@ public class EntityHogBase extends EntityAnimaniaPig implements TOPInfoProviderP
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.pigHurt1;
@@ -214,8 +212,7 @@ public class EntityHogBase extends EntityAnimaniaPig implements TOPInfoProviderP
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.pigHurt1;

--- a/src/main/java/com/animania/common/entities/pigs/EntityPigletBase.java
+++ b/src/main/java/com/animania/common/entities/pigs/EntityPigletBase.java
@@ -1,6 +1,5 @@
 package com.animania.common.entities.pigs;
 
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -28,6 +27,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.interfaces.IChild;
@@ -146,8 +146,7 @@ public class EntityPigletBase extends EntityAnimaniaPig implements TOPInfoProvid
 		else
 			num = 32;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.piglet1;
@@ -167,8 +166,7 @@ public class EntityPigletBase extends EntityAnimaniaPig implements TOPInfoProvid
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.pigletHurt1;
@@ -181,8 +179,7 @@ public class EntityPigletBase extends EntityAnimaniaPig implements TOPInfoProvid
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.pigletHurt1;

--- a/src/main/java/com/animania/common/entities/pigs/EntitySowBase.java
+++ b/src/main/java/com/animania/common/entities/pigs/EntitySowBase.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.pigs;
 
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -36,6 +35,7 @@ import net.minecraftforge.event.entity.living.BabyEntitySpawnEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.interfaces.IMateable;
@@ -309,8 +309,7 @@ public class EntitySowBase extends EntityAnimaniaPig implements TOPInfoProviderP
 		else
 			num = 40;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.pig1;
@@ -332,8 +331,7 @@ public class EntitySowBase extends EntityAnimaniaPig implements TOPInfoProviderP
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.pigHurt1;
@@ -346,8 +344,7 @@ public class EntitySowBase extends EntityAnimaniaPig implements TOPInfoProviderP
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.pigHurt1;

--- a/src/main/java/com/animania/common/entities/pigs/PigType.java
+++ b/src/main/java/com/animania/common/entities/pigs/PigType.java
@@ -2,8 +2,8 @@ package com.animania.common.entities.pigs;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Random;
 
+import com.animania.Animania;
 import com.animania.common.entities.AnimaniaType;
 
 import net.minecraft.world.World;
@@ -105,11 +105,7 @@ public enum PigType implements AnimaniaType
 
 	public static PigType breed(PigType male, PigType female)
 	{
-		Random rand = new Random();
-		if(rand.nextInt(2) == 0)
-			return male;
-		else
-			return female;
+		return Animania.RANDOM.nextBoolean() ? male : female;
 	}
 
 	

--- a/src/main/java/com/animania/common/entities/pigs/ai/EntityAIFindMud.java
+++ b/src/main/java/com/animania/common/entities/pigs/ai/EntityAIFindMud.java
@@ -1,8 +1,8 @@
 package com.animania.common.entities.pigs.ai;
 
 import java.util.List;
-import java.util.Random;
 
+import com.animania.Animania;
 import com.animania.common.entities.pigs.EntityAnimaniaPig;
 import com.animania.common.entities.pigs.EntityHogBase;
 import com.animania.common.entities.pigs.EntityPigletBase;
@@ -67,7 +67,6 @@ public class EntityAIFindMud extends EntityAIBase
 				return false;
 			}
 
-			Random rand = new Random();
 			BlockPos currentpos = new BlockPos(this.entityIn.posX, this.entityIn.posY, this.entityIn.posZ);
 			Block poschk = this.entityIn.world.getBlockState(currentpos).getBlock();
 			if (poschk == BlockHandler.blockMud || poschk.getUnlocalizedName().equals("tile.mud")) {
@@ -96,7 +95,7 @@ public class EntityAIFindMud extends EntityAIBase
 
 						if (blockchk != null && (blockchk == BlockHandler.blockMud || blockchk.getUnlocalizedName().equals("tile.mud")) && others.size() < 2) {
 							mudFound = true;
-							if (rand.nextInt(200) == 0) {
+							if (Animania.RANDOM.nextInt(200) == 0) {
 								this.delayTemptCounter = 0;
 								return false;
 							}

--- a/src/main/java/com/animania/common/entities/pigs/ai/EntityAIFollowParentPigs.java
+++ b/src/main/java/com/animania/common/entities/pigs/ai/EntityAIFollowParentPigs.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.pigs.ai;
 
 import java.util.List;
-import java.util.Random;
 
 import com.animania.common.entities.pigs.EntityAnimaniaPig;
 import com.animania.common.entities.pigs.EntityPigletBase;
@@ -19,7 +18,6 @@ public class EntityAIFollowParentPigs extends EntityAIBase
 	EntityAnimaniaPig parentAnimal;
 	double       moveSpeed;
 	private int  delayCounter;
-	Random       rand = new Random();
 
 	public EntityAIFollowParentPigs(EntityAnimaniaPig animal, double speed) {
 		this.childAnimal = animal;

--- a/src/main/java/com/animania/common/entities/pigs/ai/EntityAIMatePigs.java
+++ b/src/main/java/com/animania/common/entities/pigs/ai/EntityAIMatePigs.java
@@ -1,9 +1,9 @@
 package com.animania.common.entities.pigs.ai;
 
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
+import com.animania.Animania;
 import com.animania.common.entities.pigs.EntityAnimaniaPig;
 import com.animania.common.entities.pigs.EntityHogBase;
 import com.animania.common.entities.pigs.EntityPigletBase;
@@ -23,7 +23,6 @@ public class EntityAIMatePigs extends EntityAIBase
 	int                        			courtshipTimer;
 	double                     			moveSpeed;
 	private int                			delayCounter;
-	private Random			   			rand;
 
 	public EntityAIMatePigs(EntityAnimaniaPig animal, double speedIn) {
 		this.theAnimal = animal;
@@ -32,7 +31,6 @@ public class EntityAIMatePigs extends EntityAIBase
 		this.setMutexBits(3);
 		this.courtshipTimer = 20;
 		this.delayCounter = 0;
-		this.rand = new Random();
 
 	}
 
@@ -82,8 +80,7 @@ public class EntityAIMatePigs extends EntityAIBase
 
 			this.targetMate = (EntityAnimaniaPig) this.getNearbyMate();
 
-			Random rand = new Random();
-			if (this.targetMate != null && rand.nextInt(20) == 0) {
+			if (this.targetMate != null && Animania.RANDOM.nextInt(20) == 0) {
 				this.delayCounter = 0;
 				this.resetTask();
 				return false;

--- a/src/main/java/com/animania/common/entities/props/EntityWagon.java
+++ b/src/main/java/com/animania/common/entities/props/EntityWagon.java
@@ -55,7 +55,6 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import scala.util.Random;
 
 public class EntityWagon extends AnimatedEntityBase implements IInventoryChangedListener
 {
@@ -1021,15 +1020,14 @@ public class EntityWagon extends AnimatedEntityBase implements IInventoryChanged
 	{
 		BlockPos.MutableBlockPos blockpos$mutableblockpos = new BlockPos.MutableBlockPos(MathHelper.floor(this.posX), 0, MathHelper.floor(this.posZ));
 
-		Random rand = new Random();
 		long time = this.getEntityWorld().getWorldTime() % 24000;
 
 		if (this.world.isBlockLoaded(blockpos$mutableblockpos))
 		{
 			blockpos$mutableblockpos.setY(MathHelper.floor(this.posY + (double)this.getEyeHeight()));
 
-			if (rand.nextInt(32) == 0 && time > 13000 && sleepTimer == 0)  {
-				lastLighting = 85 + rand.nextInt(22);
+			if (Animania.RANDOM.nextInt(32) == 0 && time > 13000 && sleepTimer == 0)  {
+				lastLighting = 85 + Animania.RANDOM.nextInt(22);
 				return this.world.getCombinedLight(blockpos$mutableblockpos, 0) + lastLighting;
 
 			} else if (sleepTimer == 0 || time < 13000) {

--- a/src/main/java/com/animania/common/entities/rodents/EntityFerretBase.java
+++ b/src/main/java/com/animania/common/entities/rodents/EntityFerretBase.java
@@ -1,6 +1,5 @@
 package com.animania.common.entities.rodents;
 
-import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
@@ -426,8 +425,7 @@ public class EntityFerretBase extends EntityTameable implements TOPInfoProviderR
 		else
 			num = 40;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.ferretLiving1;
@@ -449,8 +447,7 @@ public class EntityFerretBase extends EntityTameable implements TOPInfoProviderR
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.ferretHurt1;

--- a/src/main/java/com/animania/common/entities/rodents/EntityHamster.java
+++ b/src/main/java/com/animania/common/entities/rodents/EntityHamster.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.rodents;
 
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
@@ -1137,8 +1136,7 @@ public class EntityHamster extends EntityTameable implements TOPInfoProviderRode
 		else
 			num = 24;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.hamsterLiving1;

--- a/src/main/java/com/animania/common/entities/rodents/EntityHedgehogBase.java
+++ b/src/main/java/com/animania/common/entities/rodents/EntityHedgehogBase.java
@@ -1,6 +1,5 @@
 package com.animania.common.entities.rodents;
 
-import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
@@ -342,8 +341,7 @@ public class EntityHedgehogBase extends EntityTameable implements TOPInfoProvide
 		else
 			num = 40;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 		if (chooser == 0)
 			return ModSoundEvents.hedgehogLiving1;
 		else if (chooser == 1)
@@ -362,8 +360,7 @@ public class EntityHedgehogBase extends EntityTameable implements TOPInfoProvide
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.hedgehogHurt1;

--- a/src/main/java/com/animania/common/entities/rodents/ai/EntityAIFerretFindNests.java
+++ b/src/main/java/com/animania/common/entities/rodents/ai/EntityAIFerretFindNests.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.rodents.ai;
 
-import java.util.Random;
-
+import com.animania.Animania;
 import com.animania.common.entities.rodents.EntityFerretBase;
 import com.animania.common.handler.BlockHandler;
 import com.animania.common.tileentities.TileEntityNest;
@@ -109,7 +108,6 @@ public class EntityAIFerretFindNests extends EntityAIBase
 			double z = this.temptedEntity.posZ;
 
 			boolean foodFound = false;
-			Random rand = new Random();
 
 			BlockPos pos = new BlockPos(x, y, z);
 
@@ -131,7 +129,7 @@ public class EntityAIFerretFindNests extends EntityAIBase
 							if (te != null && (te.getNestContent() == NestContent.CHICKEN_BROWN || te.getNestContent() == NestContent.CHICKEN_WHITE) )
 							{
 								foodFound = true;
-								if (rand.nextInt(200) == 0)
+								if (Animania.RANDOM.nextInt(200) == 0)
 								{
 									this.delayTemptCounter = 0;
 									return false;

--- a/src/main/java/com/animania/common/entities/rodents/ai/EntityAIFollowParentRabbits.java
+++ b/src/main/java/com/animania/common/entities/rodents/ai/EntityAIFollowParentRabbits.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.rodents.ai;
 
 import java.util.List;
-import java.util.Random;
 
 import com.animania.common.entities.rodents.rabbits.EntityRabbitDoeBase;
 import com.animania.common.entities.rodents.rabbits.EntityRabbitKitBase;
@@ -18,7 +17,6 @@ public class EntityAIFollowParentRabbits extends EntityAIBase
 	EntityAnimal parentAnimal;
 	double       moveSpeed;
 	private int  delayCounter;
-	Random       rand = new Random();
 
 	public EntityAIFollowParentRabbits(EntityAnimal animal, double speed) {
 		this.childAnimal = animal;

--- a/src/main/java/com/animania/common/entities/rodents/ai/EntityAIHedgehogFindNests.java
+++ b/src/main/java/com/animania/common/entities/rodents/ai/EntityAIHedgehogFindNests.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.rodents.ai;
 
-import java.util.Random;
-
+import com.animania.Animania;
 import com.animania.common.entities.rodents.EntityHedgehogBase;
 import com.animania.common.handler.BlockHandler;
 import com.animania.common.tileentities.TileEntityNest;
@@ -116,7 +115,6 @@ public class EntityAIHedgehogFindNests extends EntityAIBase
 			double z = this.temptedEntity.posZ;
 
 			boolean foodFound = false;
-			Random rand = new Random();
 
 			BlockPos pos = new BlockPos(x, y, z);
 
@@ -136,7 +134,7 @@ public class EntityAIHedgehogFindNests extends EntityAIBase
 							if (te != null && (te.getNestContent() == NestContent.CHICKEN_BROWN || te.getNestContent() == NestContent.CHICKEN_WHITE) )
 							{
 								foodFound = true;
-								if (rand.nextInt(200) == 0)
+								if (Animania.RANDOM.nextInt(200) == 0)
 								{
 									this.delayTemptCounter = 0;
 									return false;
@@ -155,7 +153,7 @@ public class EntityAIHedgehogFindNests extends EntityAIBase
 						{
 
 							foodFound = true;
-							if (rand.nextInt(200) == 0)
+							if (Animania.RANDOM.nextInt(200) == 0)
 							{
 								this.delayTemptCounter = 0;
 								return false;

--- a/src/main/java/com/animania/common/entities/rodents/ai/EntityAIMateRabbits.java
+++ b/src/main/java/com/animania/common/entities/rodents/ai/EntityAIMateRabbits.java
@@ -1,9 +1,9 @@
 package com.animania.common.entities.rodents.ai;
 
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
+import com.animania.Animania;
 import com.animania.common.entities.pigs.EntityAnimaniaPig;
 import com.animania.common.entities.rodents.rabbits.EntityAnimaniaRabbit;
 import com.animania.common.entities.rodents.rabbits.EntityRabbitBuckBase;
@@ -24,7 +24,6 @@ public class EntityAIMateRabbits extends EntityAIBase
 	int                        courtshipTimer;
 	double                     moveSpeed;
 	private int                delayCounter;
-	private Random			   rand;
 
 	public EntityAIMateRabbits(EntityAnimal animal, double speedIn) {
 		this.theAnimal = animal;
@@ -33,7 +32,6 @@ public class EntityAIMateRabbits extends EntityAIBase
 		this.setMutexBits(3);
 		this.courtshipTimer = 20;
 		this.delayCounter = 0;
-		this.rand = new Random();
 
 	}
 
@@ -79,8 +77,7 @@ public class EntityAIMateRabbits extends EntityAIBase
 
 			this.targetMate = this.getNearbyMate();
 
-			Random rand = new Random();
-			if (this.targetMate != null && rand.nextInt(20) == 0) {
+			if (this.targetMate != null && Animania.RANDOM.nextInt(20) == 0) {
 				this.delayCounter = 0;
 				this.resetTask();
 				return false;

--- a/src/main/java/com/animania/common/entities/rodents/rabbits/EntityRabbitBuckBase.java
+++ b/src/main/java/com/animania/common/entities/rodents/rabbits/EntityRabbitBuckBase.java
@@ -2,7 +2,6 @@ package com.animania.common.entities.rodents.rabbits;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -31,6 +30,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.cows.EntityBullBase;
@@ -92,8 +92,7 @@ public class EntityRabbitBuckBase extends EntityAnimaniaRabbit implements TOPInf
 		else
 			num = 32;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.rabbit1;
@@ -111,25 +110,13 @@ public class EntityRabbitBuckBase extends EntityAnimaniaRabbit implements TOPInf
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
-
-		if (chooser == 0)
-			return ModSoundEvents.rabbitHurt1;
-		else
-			return ModSoundEvents.rabbitHurt2;
+		return Animania.RANDOM.nextBoolean() ? ModSoundEvents.rabbitHurt1 : ModSoundEvents.rabbitHurt2;
 	}
 
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
-
-		if (chooser == 0)
-			return ModSoundEvents.rabbitHurt1;
-		else
-			return ModSoundEvents.rabbitHurt2;
+		return Animania.RANDOM.nextBoolean() ? ModSoundEvents.rabbitHurt1 : ModSoundEvents.rabbitHurt2;
 	}
 
 	@Override

--- a/src/main/java/com/animania/common/entities/rodents/rabbits/EntityRabbitDoeBase.java
+++ b/src/main/java/com/animania/common/entities/rodents/rabbits/EntityRabbitDoeBase.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.rodents.rabbits;
 
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -37,6 +36,7 @@ import net.minecraftforge.event.entity.living.BabyEntitySpawnEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.interfaces.IMateable;
@@ -251,8 +251,7 @@ public class EntityRabbitDoeBase extends EntityAnimaniaRabbit implements TOPInfo
 		else
 			num = 32;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.rabbit1;
@@ -270,25 +269,13 @@ public class EntityRabbitDoeBase extends EntityAnimaniaRabbit implements TOPInfo
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
-
-		if (chooser == 0)
-			return ModSoundEvents.rabbitHurt1;
-		else
-			return ModSoundEvents.rabbitHurt2;
+		return Animania.RANDOM.nextBoolean() ? ModSoundEvents.rabbitHurt1 : ModSoundEvents.rabbitHurt2;
 	}
 
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
-
-		if (chooser == 0)
-			return ModSoundEvents.rabbitHurt1;
-		else
-			return ModSoundEvents.rabbitHurt2;
+		return Animania.RANDOM.nextBoolean() ? ModSoundEvents.rabbitHurt1 : ModSoundEvents.rabbitHurt2;
 	}
 
 	@Override

--- a/src/main/java/com/animania/common/entities/rodents/rabbits/EntityRabbitKitBase.java
+++ b/src/main/java/com/animania/common/entities/rodents/rabbits/EntityRabbitKitBase.java
@@ -1,6 +1,5 @@
 package com.animania.common.entities.rodents.rabbits;
 
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -20,6 +19,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.interfaces.IChild;
@@ -137,8 +137,7 @@ public class EntityRabbitKitBase extends EntityAnimaniaRabbit implements TOPInfo
 		else
 			num = 32;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.rabbit1;
@@ -156,25 +155,13 @@ public class EntityRabbitKitBase extends EntityAnimaniaRabbit implements TOPInfo
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
-
-		if (chooser == 0)
-			return ModSoundEvents.rabbitHurt1;
-		else
-			return ModSoundEvents.rabbitHurt2;
+		return Animania.RANDOM.nextBoolean() ? ModSoundEvents.rabbitHurt1 : ModSoundEvents.rabbitHurt2;
 	}
 
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
-
-		if (chooser == 0)
-			return ModSoundEvents.rabbitHurt1;
-		else
-			return ModSoundEvents.rabbitHurt2;
+		return Animania.RANDOM.nextBoolean() ? ModSoundEvents.rabbitHurt1 : ModSoundEvents.rabbitHurt2;
 	}
 
 	@Override

--- a/src/main/java/com/animania/common/entities/rodents/rabbits/RabbitType.java
+++ b/src/main/java/com/animania/common/entities/rodents/rabbits/RabbitType.java
@@ -2,8 +2,8 @@ package com.animania.common.entities.rodents.rabbits;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Random;
 
+import com.animania.Animania;
 import com.animania.common.entities.AnimaniaType;
 
 import net.minecraft.stats.StatBase;
@@ -111,11 +111,7 @@ public enum RabbitType implements AnimaniaType
 
 	public static RabbitType breed(RabbitType male, RabbitType female)
 	{
-		Random rand = new Random();
-		if(rand.nextInt(2) == 0)
-			return male;
-		else
-			return female;
+		return Animania.RANDOM.nextBoolean() ?  male : female;
 	}
 
 	public StatBase getAchievement()

--- a/src/main/java/com/animania/common/entities/sheep/EntityEweBase.java
+++ b/src/main/java/com/animania/common/entities/sheep/EntityEweBase.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.sheep;
 
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -41,6 +40,7 @@ import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.interfaces.IMateable;
@@ -254,8 +254,7 @@ public class EntityEweBase extends EntityAnimaniaSheep implements TOPInfoProvide
 		else
 			num = 40;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.sheepLiving1;
@@ -279,8 +278,7 @@ public class EntityEweBase extends EntityAnimaniaSheep implements TOPInfoProvide
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
+		int chooser = Animania.RANDOM.nextInt(2);
 
 		if (chooser == 0)
 			return ModSoundEvents.sheepHurt1;
@@ -291,8 +289,7 @@ public class EntityEweBase extends EntityAnimaniaSheep implements TOPInfoProvide
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 		if (chooser == 0)
 			return ModSoundEvents.sheepHurt1;
 		else

--- a/src/main/java/com/animania/common/entities/sheep/EntityLambBase.java
+++ b/src/main/java/com/animania/common/entities/sheep/EntityLambBase.java
@@ -1,6 +1,5 @@
 package com.animania.common.entities.sheep;
 
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -20,6 +19,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.interfaces.IChild;
@@ -137,8 +137,7 @@ public class EntityLambBase extends EntityAnimaniaSheep implements TOPInfoProvid
 		else
 			num = 32;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.lambLiving1;
@@ -152,8 +151,7 @@ public class EntityLambBase extends EntityAnimaniaSheep implements TOPInfoProvid
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.sheepHurt1;
@@ -166,8 +164,7 @@ public class EntityLambBase extends EntityAnimaniaSheep implements TOPInfoProvid
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 
 		if (chooser == 0)
 			return ModSoundEvents.sheepHurt1;

--- a/src/main/java/com/animania/common/entities/sheep/EntityRamBase.java
+++ b/src/main/java/com/animania/common/entities/sheep/EntityRamBase.java
@@ -2,7 +2,6 @@ package com.animania.common.entities.sheep;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -32,6 +31,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.cows.EntityBullBase;
@@ -132,8 +132,7 @@ public class EntityRamBase extends EntityAnimaniaSheep implements TOPInfoProvide
 		else
 			num = 40;
 
-		Random rand = new Random();
-		int chooser = rand.nextInt(num);
+		int chooser = Animania.RANDOM.nextInt(num);
 
 		if (chooser == 0)
 			return ModSoundEvents.sheepLiving1;
@@ -157,8 +156,7 @@ public class EntityRamBase extends EntityAnimaniaSheep implements TOPInfoProvide
 	@Override
 	protected SoundEvent getHurtSound(DamageSource source)
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(2);
+		int chooser = Animania.RANDOM.nextInt(2);
 
 		if (chooser == 0)
 			return ModSoundEvents.sheepHurt1;
@@ -169,8 +167,7 @@ public class EntityRamBase extends EntityAnimaniaSheep implements TOPInfoProvide
 	@Override
 	protected SoundEvent getDeathSound()
 	{
-		Random rand = new Random();
-		int chooser = rand.nextInt(3);
+		int chooser = Animania.RANDOM.nextInt(3);
 		if (chooser == 0)
 			return ModSoundEvents.sheepHurt1;
 		else

--- a/src/main/java/com/animania/common/entities/sheep/SheepType.java
+++ b/src/main/java/com/animania/common/entities/sheep/SheepType.java
@@ -2,8 +2,8 @@ package com.animania.common.entities.sheep;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.Random;
 
+import com.animania.Animania;
 import com.animania.common.entities.AnimaniaType;
 
 import net.minecraft.stats.StatBase;
@@ -107,11 +107,7 @@ public enum SheepType implements AnimaniaType
 
 	public static SheepType breed(SheepType male, SheepType female)
 	{
-		Random rand = new Random();
-		if(rand.nextInt(2) == 0)
-			return male;
-		else
-			return female;
+		return Animania.RANDOM.nextBoolean() ? male : female;
 	}
 
 	public StatBase getAchievement()

--- a/src/main/java/com/animania/common/entities/sheep/ai/EntityAIButtHeadsSheep.java
+++ b/src/main/java/com/animania/common/entities/sheep/ai/EntityAIButtHeadsSheep.java
@@ -1,8 +1,8 @@
 package com.animania.common.entities.sheep.ai;
 
 import java.util.List;
-import java.util.Random;
 
+import com.animania.Animania;
 import com.animania.common.entities.sheep.EntityEweBase;
 import com.animania.common.entities.sheep.EntityLambBase;
 import com.animania.common.entities.sheep.EntityRamBase;
@@ -20,7 +20,6 @@ public class EntityAIButtHeadsSheep extends EntityAIBase
 	int fightTimer;
 	double moveSpeed;
 	private int delayCounter;
-	Random rand = new Random();
 
 
 	public EntityAIButtHeadsSheep(EntityAnimal animal, double speedIn)
@@ -29,7 +28,7 @@ public class EntityAIButtHeadsSheep extends EntityAIBase
 		this.theWorld = animal.world;
 		this.moveSpeed = speedIn;
 		this.setMutexBits(3);
-		this.fightTimer = 100 + rand.nextInt(50);
+		this.fightTimer = 100 + Animania.RANDOM.nextInt(50);
 		this.delayCounter = 0;
 
 	}
@@ -51,8 +50,7 @@ public class EntityAIButtHeadsSheep extends EntityAIBase
 			
 			this.targetMate = this.getNearbyRival();
 
-			Random rand = new Random();
-			if (this.targetMate != null && rand.nextInt(20) == 0) {
+			if (this.targetMate != null && Animania.RANDOM.nextInt(20) == 0) {
 				this.delayCounter = 0;
 				this.resetTask();
 				return false;
@@ -136,7 +134,7 @@ public class EntityAIButtHeadsSheep extends EntityAIBase
 			if (foundEntity != null) {
 				
 				if (this.fightTimer < 0 && thisEntity.getFighting()) {
-					this.fightTimer = 100 + rand.nextInt(50);
+					this.fightTimer = 100 + Animania.RANDOM.nextInt(50);
 					this.targetMate = null;
 					thisEntity.setFighting(false);
 					foundEntity.setFighting(false);
@@ -159,7 +157,7 @@ public class EntityAIButtHeadsSheep extends EntityAIBase
 
 				} 
 			} else if (foundEntity == null || fightTimer < 0) {
-				this.fightTimer = 100 + rand.nextInt(50);
+				this.fightTimer = 100 + Animania.RANDOM.nextInt(50);
 				this.targetMate = null;
 				thisEntity.setFighting(false);
 				thisEntity.setRivalUniqueId(null);

--- a/src/main/java/com/animania/common/entities/sheep/ai/EntityAIFollowParentSheep.java
+++ b/src/main/java/com/animania/common/entities/sheep/ai/EntityAIFollowParentSheep.java
@@ -1,7 +1,6 @@
 package com.animania.common.entities.sheep.ai;
 
 import java.util.List;
-import java.util.Random;
 
 import com.animania.common.entities.sheep.EntityAnimaniaSheep;
 import com.animania.common.entities.sheep.EntityEweBase;
@@ -18,7 +17,6 @@ public class EntityAIFollowParentSheep extends EntityAIBase
 	EntityAnimaniaSheep parentAnimal;
 	double moveSpeed;
 	private int delayCounter;
-	Random rand = new Random();
 
 	public EntityAIFollowParentSheep(EntityAnimal animal, double speed)
 	{

--- a/src/main/java/com/animania/common/entities/sheep/ai/EntityAIMateSheep.java
+++ b/src/main/java/com/animania/common/entities/sheep/ai/EntityAIMateSheep.java
@@ -1,9 +1,9 @@
 package com.animania.common.entities.sheep.ai;
 
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 
+import com.animania.Animania;
 import com.animania.common.entities.sheep.EntityAnimaniaSheep;
 import com.animania.common.entities.sheep.EntityEweBase;
 import com.animania.common.entities.sheep.EntityLambBase;
@@ -23,7 +23,6 @@ public class EntityAIMateSheep extends EntityAIBase
 	int                  		      courtshipTimer;
 	double           		          moveSpeed;
 	private int      		          delayCounter;
-	private Random					   rand;
 
 	public EntityAIMateSheep(EntityAnimal animal, double speedIn) {
 		this.theAnimal = (EntityAnimaniaSheep) animal;
@@ -32,7 +31,6 @@ public class EntityAIMateSheep extends EntityAIBase
 		this.setMutexBits(3);
 		this.courtshipTimer = 20;
 		this.delayCounter = 0;
-		this.rand = new Random();
 
 	}
 
@@ -82,8 +80,7 @@ public class EntityAIMateSheep extends EntityAIBase
 
 			this.targetMate = (EntityAnimaniaSheep) this.getNearbyMate();
 
-			Random rand = new Random();
-			if (this.targetMate != null && rand.nextInt(20) == 0) {
+			if (this.targetMate != null && Animania.RANDOM.nextInt(20) == 0) {
 				this.delayCounter = 0;
 				this.resetTask();
 				return false;

--- a/src/main/java/com/animania/common/events/EventReplaceSpawnAnimals.java
+++ b/src/main/java/com/animania/common/events/EventReplaceSpawnAnimals.java
@@ -1,9 +1,9 @@
 package com.animania.common.events;
 
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 
+import com.animania.Animania;
 import com.animania.common.entities.amphibians.EntityAmphibian;
 import com.animania.common.entities.chickens.EntityAnimaniaChicken;
 import com.animania.common.entities.chickens.EntityHenBase;
@@ -117,7 +117,6 @@ public class EventReplaceSpawnAnimals
 
 		BlockPos pos = new BlockPos(event.getEntity().posX, event.getEntity().posY, event.getEntity().posZ);
 		World worldIn = event.getWorld();
-		Random rand = new Random();
 		Biome biome = event.getWorld().getBiome(pos);
 		int chooser = 0;
 
@@ -132,7 +131,7 @@ public class EventReplaceSpawnAnimals
 			List<EntityAnimaniaCow> others = AnimaniaHelper.getEntitiesInRange(EntityAnimaniaCow.class, 32, event.getEntity().world, pos);
 			if (others.size() < 2)
 			{
-				chooser = rand.nextInt(3);
+				chooser = Animania.RANDOM.nextInt(3);
 				
 				if (BiomeDictionary.hasType(biome, AnimaniaHelper.getBiomeTypes(AnimaniaConfig.spawnLocations.cowHolsteinBiomeTypes)[0])) {
 					if (chooser == 2) {
@@ -245,10 +244,10 @@ public class EventReplaceSpawnAnimals
 			List<EntityAnimaniaPig> others = AnimaniaHelper.getEntitiesInRange(EntityAnimaniaPig.class, 32, event.getEntity().world, pos);
 			if (others.size() < 2)
 			{
-				chooser = rand.nextInt(3);
+				chooser = Animania.RANDOM.nextInt(3);
 
 				if (BiomeDictionary.hasType(biome, AnimaniaHelper.getBiomeTypes(AnimaniaConfig.spawnLocations.pigOldSpotBiomeTypes)[0])) {
-					if (rand.nextBoolean()) {
+					if (Animania.RANDOM.nextBoolean()) {
 						if (chooser == 2) {
 							EntitySowOldSpot entity = new EntitySowOldSpot(worldIn);
 							entity.setPosition(event.getEntity().posX, event.getEntity().posY, event.getEntity().posZ);
@@ -333,7 +332,7 @@ public class EventReplaceSpawnAnimals
 			List<EntityAnimaniaChicken> others = AnimaniaHelper.getEntitiesInRange(EntityAnimaniaChicken.class, 32, event.getEntity().world, pos);
 			if (others.size() < 2)
 			{
-				chooser = rand.nextInt(3);
+				chooser = Animania.RANDOM.nextInt(3);
 
 				if (BiomeDictionary.hasType(biome, AnimaniaHelper.getBiomeTypes(AnimaniaConfig.spawnLocations.chickenOrpingtonBiomeTypes)[0])) {
 					if (chooser == 2) {
@@ -417,10 +416,10 @@ public class EventReplaceSpawnAnimals
 			List<EntityAnimaniaSheep> others = AnimaniaHelper.getEntitiesInRange(EntityAnimaniaSheep.class, 32, event.getEntity().world, pos);
 			if (others.size() < 2)
 			{
-				chooser = rand.nextInt(3);
+				chooser = Animania.RANDOM.nextInt(3);
 
 				if (BiomeDictionary.hasType(biome, AnimaniaHelper.getBiomeTypes(AnimaniaConfig.spawnLocations.sheepDorsetBiomeTypes)[0])) {
-					int chooser2 = rand.nextInt(2);
+					int chooser2 = Animania.RANDOM.nextInt(2);
 					if (chooser2 == 0)
 					{
 						if (chooser == 2)
@@ -524,7 +523,7 @@ public class EventReplaceSpawnAnimals
 			List<EntityAnimaniaSheep> others = AnimaniaHelper.getEntitiesInRange(EntityAnimaniaSheep.class, 32, event.getEntity().world, pos);
 			if (others.size() < 2)
 			{
-				chooser = rand.nextInt(3);
+				chooser = Animania.RANDOM.nextInt(3);
 
 				if (BiomeDictionary.hasType(biome, AnimaniaHelper.getBiomeTypes(AnimaniaConfig.spawnLocations.rabbitCottontailBiomeTypes)[0])) {
 					if (chooser == 2) {
@@ -685,7 +684,6 @@ public class EventReplaceSpawnAnimals
 	{
 		BlockPos pos = new BlockPos(event.getEntity().posX, event.getEntity().posY, event.getEntity().posZ);
 		World worldIn = event.getWorld();
-		Random rand = new Random();
 		Biome biome = event.getWorld().getBiome(pos);
 		int chooser = 0;
 

--- a/src/main/java/com/animania/common/events/InteractHandler.java
+++ b/src/main/java/com/animania/common/events/InteractHandler.java
@@ -1,7 +1,5 @@
 package com.animania.common.events;
 
-import java.util.Random;
-
 import net.minecraft.block.BlockFarmland;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
@@ -88,8 +86,7 @@ public class InteractHandler
 						if (!player.isCreative())
 							stack.shrink(1);
 
-						Random rand = new Random();
-						event.getWorld().playSound(null, event.getEntityPlayer().posX, event.getEntityPlayer().posY, event.getEntityPlayer().posZ, SoundEvents.BLOCK_GRASS_FALL, SoundCategory.PLAYERS, 0.2F, ((rand.nextFloat() - rand.nextFloat()) * 0.2F + 1.0F) / 0.8F);
+						event.getWorld().playSound(null, event.getEntityPlayer().posX, event.getEntityPlayer().posY, event.getEntityPlayer().posZ, SoundEvents.BLOCK_GRASS_FALL, SoundCategory.PLAYERS, 0.2F, ((Animania.RANDOM.nextFloat() - Animania.RANDOM.nextFloat()) * 0.2F + 1.0F) / 0.8F);
 					}
 				}
 			}
@@ -200,8 +197,7 @@ public class InteractHandler
 				props.setCarrying(false);
 				props.setType("");
 				player.swingArm(EnumHand.MAIN_HAND);
-				Random rand = new Random();
-				player.playSound(SoundEvents.ENTITY_ITEM_PICKUP, 1.0F, (rand.nextFloat() - rand.nextFloat()) * 0.2F + 1.0F);
+				player.playSound(SoundEvents.ENTITY_ITEM_PICKUP, 1.0F, (Animania.RANDOM.nextFloat() - Animania.RANDOM.nextFloat()) * 0.2F + 1.0F);
 				event.setCanceled(true);
 				Animania.network.sendToAllAround(new CapSyncPacket(props, player.getEntityId()), new NetworkRegistry.TargetPoint(player.world.provider.getDimension(), player.getPosition().getX(), player.getPosition().getY(), player.getPosition().getZ(), 64));
 			}

--- a/src/main/java/com/animania/common/handler/DispenserHandler.java
+++ b/src/main/java/com/animania/common/handler/DispenserHandler.java
@@ -1,7 +1,6 @@
 package com.animania.common.handler;
 
-import java.util.Random;
-
+import com.animania.Animania;
 import com.animania.common.blocks.BlockSeeds;
 import com.animania.common.entities.EntityGender;
 import com.animania.common.entities.RandomAnimalType;
@@ -120,30 +119,29 @@ public class DispenserHandler
 
 			if (item.gender == EntityGender.RANDOM)
 			{
-				Random rand = new Random();
 				if (item.type instanceof CowType)
 				{
-					entity = EntityGender.getEntity(CowType.values()[rand.nextInt(((CowType) item.type).values().length)], item.gender, world);
+					entity = EntityGender.getEntity(CowType.values()[Animania.RANDOM.nextInt(((CowType) item.type).values().length)], item.gender, world);
 				}
 				if (item.type instanceof PigType)
 				{
-					entity = EntityGender.getEntity(PigType.values()[rand.nextInt(((PigType) item.type).values().length)], item.gender, world);
+					entity = EntityGender.getEntity(PigType.values()[Animania.RANDOM.nextInt(((PigType) item.type).values().length)], item.gender, world);
 				}
 				if (item.type instanceof ChickenType)
 				{
-					entity = EntityGender.getEntity(ChickenType.values()[rand.nextInt(((ChickenType) item.type).values().length)], item.gender, world);
+					entity = EntityGender.getEntity(ChickenType.values()[Animania.RANDOM.nextInt(((ChickenType) item.type).values().length)], item.gender, world);
 				}
 				if(item.type instanceof GoatType)
 				{
-					entity = EntityGender.getEntity(GoatType.values()[rand.nextInt(((GoatType) item.type).values().length)], item.gender, world);
+					entity = EntityGender.getEntity(GoatType.values()[Animania.RANDOM.nextInt(((GoatType) item.type).values().length)], item.gender, world);
 				}
 				if(item.type instanceof PeacockType)
 				{
-					entity = EntityGender.getEntity(PeacockType.values()[rand.nextInt(((PeacockType) item.type).values().length)], item.gender, world);
+					entity = EntityGender.getEntity(PeacockType.values()[Animania.RANDOM.nextInt(((PeacockType) item.type).values().length)], item.gender, world);
 				}
 				if(item.type instanceof RabbitType)
 				{
-					entity = EntityGender.getEntity(RabbitType.values()[rand.nextInt(((RabbitType) item.type).values().length)], item.gender, world);
+					entity = EntityGender.getEntity(RabbitType.values()[Animania.RANDOM.nextInt(((RabbitType) item.type).values().length)], item.gender, world);
 				}
 				if(item.type instanceof RandomAnimalType)
 				{

--- a/src/main/java/com/animania/common/items/ItemCart.java
+++ b/src/main/java/com/animania/common/items/ItemCart.java
@@ -1,7 +1,6 @@
 package com.animania.common.items;
 
 import java.util.List;
-import java.util.Random;
 
 import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
@@ -151,8 +150,7 @@ public class ItemCart extends Item
 		if (!playerIn.isCreative())
 			stack.shrink(1);
 
-		Random rand = new Random();
-		world.playSound(null, playerIn.posX, playerIn.posY, playerIn.posZ, ModSoundEvents.combo, SoundCategory.PLAYERS, 0.8F, ((rand.nextFloat() - rand.nextFloat()) * 0.2F + 1.0F) / 0.8F);
+		world.playSound(null, playerIn.posX, playerIn.posY, playerIn.posZ, ModSoundEvents.combo, SoundCategory.PLAYERS, 0.8F, ((Animania.RANDOM.nextFloat() - Animania.RANDOM.nextFloat()) * 0.2F + 1.0F) / 0.8F);
 		entity.rotationYaw = entity.rotationYaw;
 		entity.deltaRotation = entity.rotationYaw;
 		world.spawnEntity(entity);

--- a/src/main/java/com/animania/common/items/ItemEntityEgg.java
+++ b/src/main/java/com/animania/common/items/ItemEntityEgg.java
@@ -3,7 +3,6 @@ package com.animania.common.items;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 
 import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
@@ -85,34 +84,33 @@ public class ItemEntityEgg extends Item
 
 		if (this.gender == EntityGender.RANDOM)
 		{
-			Random rand = new Random();
 			if (type instanceof CowType)
 			{
-				entity = EntityGender.getEntity(CowType.values()[rand.nextInt(((CowType) type).values().length)], gender, world);
+				entity = EntityGender.getEntity(CowType.values()[Animania.RANDOM.nextInt(((CowType) type).values().length)], gender, world);
 			}
 			if (type instanceof PigType)
 			{
-				entity = EntityGender.getEntity(PigType.values()[rand.nextInt(((PigType) type).values().length)], gender, world);
+				entity = EntityGender.getEntity(PigType.values()[Animania.RANDOM.nextInt(((PigType) type).values().length)], gender, world);
 			}
 			if (type instanceof ChickenType)
 			{
-				entity = EntityGender.getEntity(ChickenType.values()[rand.nextInt(((ChickenType) type).values().length)], gender, world);
+				entity = EntityGender.getEntity(ChickenType.values()[Animania.RANDOM.nextInt(((ChickenType) type).values().length)], gender, world);
 			}
 			if(type instanceof GoatType)
 			{
-				entity = EntityGender.getEntity(GoatType.values()[rand.nextInt(((GoatType) type).values().length)], gender, world);
+				entity = EntityGender.getEntity(GoatType.values()[Animania.RANDOM.nextInt(((GoatType) type).values().length)], gender, world);
 			}
 			if(type instanceof PeacockType)
 			{
-				entity = EntityGender.getEntity(PeacockType.values()[rand.nextInt(((PeacockType) type).values().length)], gender, world);
+				entity = EntityGender.getEntity(PeacockType.values()[Animania.RANDOM.nextInt(((PeacockType) type).values().length)], gender, world);
 			}
 			if(type instanceof RabbitType)
 			{
-				entity = EntityGender.getEntity(RabbitType.values()[rand.nextInt(((RabbitType) type).values().length)], gender, world);
+				entity = EntityGender.getEntity(RabbitType.values()[Animania.RANDOM.nextInt(((RabbitType) type).values().length)], gender, world);
 			}
 			if(type instanceof SheepType)
 			{
-				entity = EntityGender.getEntity(SheepType.values()[rand.nextInt(((SheepType) type).values().length)], gender, world);
+				entity = EntityGender.getEntity(SheepType.values()[Animania.RANDOM.nextInt(((SheepType) type).values().length)], gender, world);
 			}
 			if(type instanceof RandomAnimalType)
 			{
@@ -134,8 +132,7 @@ public class ItemEntityEgg extends Item
 			if (!playerIn.isCreative())
 				stack.shrink(1);
 
-			Random rand = new Random();
-			world.playSound(null, playerIn.posX, playerIn.posY, playerIn.posZ, ModSoundEvents.combo, SoundCategory.PLAYERS, 0.8F, ((rand.nextFloat() - rand.nextFloat()) * 0.2F + 1.0F) / 0.8F);
+			world.playSound(null, playerIn.posX, playerIn.posY, playerIn.posZ, ModSoundEvents.combo, SoundCategory.PLAYERS, 0.8F, ((Animania.RANDOM.nextFloat() - Animania.RANDOM.nextFloat()) * 0.2F + 1.0F) / 0.8F);
 			entity.rotationYawHead = entity.rotationYaw;
 			entity.renderYawOffset = entity.rotationYaw;
 			world.spawnEntity(entity);

--- a/src/main/java/com/animania/common/items/ItemTiller.java
+++ b/src/main/java/com/animania/common/items/ItemTiller.java
@@ -1,7 +1,5 @@
 package com.animania.common.items;
 
-import java.util.Random;
-
 import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.props.EntityTiller;
@@ -51,8 +49,7 @@ public class ItemTiller extends Item
 		if (!playerIn.isCreative())
 			stack.shrink(1);
 
-		Random rand = new Random();
-		world.playSound(null, playerIn.posX, playerIn.posY, playerIn.posZ, ModSoundEvents.combo, SoundCategory.PLAYERS, 0.8F, ((rand.nextFloat() - rand.nextFloat()) * 0.2F + 1.0F) / 0.8F);
+		world.playSound(null, playerIn.posX, playerIn.posY, playerIn.posZ, ModSoundEvents.combo, SoundCategory.PLAYERS, 0.8F, ((Animania.RANDOM.nextFloat() - Animania.RANDOM.nextFloat()) * 0.2F + 1.0F) / 0.8F);
 		entity.rotationYaw = entity.rotationYaw;
 		entity.deltaRotation = entity.rotationYaw;
 		world.spawnEntity(entity);

--- a/src/main/java/com/animania/common/tileentities/TileEntityHamsterWheel.java
+++ b/src/main/java/com/animania/common/tileentities/TileEntityHamsterWheel.java
@@ -1,7 +1,5 @@
 package com.animania.common.tileentities;
 
-import java.util.Random;
-
 import javax.annotation.Nullable;
 
 import com.animania.Animania;
@@ -177,8 +175,7 @@ public class TileEntityHamsterWheel extends AnimatedTileEntity implements ITicka
 			if (findPositionForHamster())
 			{
 				world.spawnEntity(hamster);
-				Random rand = new Random();
-				hamster.playSound(SoundEvents.ENTITY_ITEM_PICKUP, 1.0F, (rand.nextFloat() - rand.nextFloat()) * 0.2F + 1.0F);
+				hamster.playSound(SoundEvents.ENTITY_ITEM_PICKUP, 1.0F, (Animania.RANDOM.nextFloat() - Animania.RANDOM.nextFloat()) * 0.2F + 1.0F);
 				// this.hamster.setWatered(false);
 				this.hamster.setFed(false);
 				this.hamster = null;

--- a/src/main/java/com/animania/common/tileentities/TileEntityHive.java
+++ b/src/main/java/com/animania/common/tileentities/TileEntityHive.java
@@ -1,7 +1,6 @@
 package com.animania.common.tileentities;
 
 import java.util.List;
-import java.util.Random;
 
 import javax.annotation.Nullable;
 
@@ -46,7 +45,6 @@ public class TileEntityHive extends AnimatedTileEntity implements ITickable
 
 	public int nextHoney = 400;
 	public FluidHandlerBeehive fluidHandler;
-	private Random rand = new Random();
 	private boolean isRunning;
 	private int nbtSyncTimer;
 
@@ -75,9 +73,9 @@ public class TileEntityHive extends AnimatedTileEntity implements ITickable
 				int filled = fluidHandler.fill(new FluidStack(BlockHandler.fluidHoney, 25), true);
 
 				if (this.getBlockType() == BlockHandler.blockHive)
-					nextHoney = AnimaniaConfig.gameRules.hivePlayermadeHoneyRate + rand.nextInt(100);
+					nextHoney = AnimaniaConfig.gameRules.hivePlayermadeHoneyRate + Animania.RANDOM.nextInt(100);
 				else 
-					nextHoney = AnimaniaConfig.gameRules.hiveWildHoneyRate + rand.nextInt(100);
+					nextHoney = AnimaniaConfig.gameRules.hiveWildHoneyRate + Animania.RANDOM.nextInt(100);
 
 
 				if (filled > 0)
@@ -87,12 +85,12 @@ public class TileEntityHive extends AnimatedTileEntity implements ITickable
 		
 		if(this.blockType == BlockHandler.blockWildHive)
 		{
-			if(this.rand.nextInt(10) == 0)
+			if(Animania.RANDOM.nextInt(10) == 0)
 			{
 				List<EntityPlayer> players = AnimaniaHelper.getEntitiesInRange(EntityPlayer.class, 2, this.world, pos);
 				for(EntityPlayer p : players)
 				{
-					if(rand.nextInt(3) == 0)
+					if(Animania.RANDOM.nextInt(3) == 0)
 						p.attackEntityFrom(DamageSourceHandler.beeDamage, 2.5f);
 				}
 			}

--- a/src/main/java/com/animania/manual/components/CraftingComponent.java
+++ b/src/main/java/com/animania/manual/components/CraftingComponent.java
@@ -2,7 +2,6 @@ package com.animania.manual.components;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Random;
 
 import com.animania.Animania;
 import com.animania.manual.gui.GuiManual;
@@ -160,7 +159,6 @@ public class CraftingComponent implements IManualComponent
 
 	private void updateIngredientIndices()
 	{
-		Random rand = new Random();
 		if (!GuiScreen.isShiftKeyDown())
 		{
 			if (ITEM_TIMER == 0)


### PR DESCRIPTION
new Something() calls are expensive. new Random() calls are even more expensive cause of the background work to be done (creating and seeding a new pseudo RNG) so let's recycle a single instance for everything. This also removes a ton of never used Random instances.