### PR TITLE
Cache mate UUID for rabbits

### DIFF
--- a/src/main/java/com/animania/common/entities/rodents/rabbits/EntityAnimaniaRabbit.java
+++ b/src/main/java/com/animania/common/entities/rodents/rabbits/EntityAnimaniaRabbit.java
@@ -498,6 +498,7 @@ public class EntityAnimaniaRabbit extends EntityRabbit implements IAnimaniaAnima
 			{
 				UUID id = (UUID) ((Optional) this.dataManager.get(EntityAnimaniaRabbit.MATE_UNIQUE_ID)).orNull();
 				this.mateUUID = id;
+				this.mateUuidCached = true;
 				return id;
 			}
 			catch (Exception e)
@@ -511,6 +512,7 @@ public class EntityAnimaniaRabbit extends EntityRabbit implements IAnimaniaAnima
 	public void setMateUniqueId(@Nullable UUID uniqueId)
 	{
 		this.mateUUID = uniqueId;
+		this.mateUuidCached = true;
 		this.dataManager.set(EntityAnimaniaRabbit.MATE_UNIQUE_ID, Optional.fromNullable(uniqueId));
 	}
 

--- a/src/main/java/com/animania/common/entities/rodents/rabbits/EntityAnimaniaRabbit.java
+++ b/src/main/java/com/animania/common/entities/rodents/rabbits/EntityAnimaniaRabbit.java
@@ -113,6 +113,9 @@ public class EntityAnimaniaRabbit extends EntityRabbit implements IAnimaniaAnima
 	private boolean wasOnGround;
 	private int currentMoveTypeDuration;
 
+	private boolean mateUuidCached = false;
+	private UUID mateUUID = null;
+
 	public EntityAnimaniaRabbit(World worldIn)
 	{
 		super(worldIn);
@@ -489,9 +492,12 @@ public class EntityAnimaniaRabbit extends EntityRabbit implements IAnimaniaAnima
 	{
 		if (mateable)
 		{
+			if(this.mateUuidCached)
+				return this.mateUUID;
 			try
 			{
 				UUID id = (UUID) ((Optional) this.dataManager.get(EntityAnimaniaRabbit.MATE_UNIQUE_ID)).orNull();
+				this.mateUUID = id;
 				return id;
 			}
 			catch (Exception e)
@@ -504,6 +510,7 @@ public class EntityAnimaniaRabbit extends EntityRabbit implements IAnimaniaAnima
 
 	public void setMateUniqueId(@Nullable UUID uniqueId)
 	{
+		this.mateUUID = uniqueId;
 		this.dataManager.set(EntityAnimaniaRabbit.MATE_UNIQUE_ID, Optional.fromNullable(uniqueId));
 	}
 


### PR DESCRIPTION
Java Profiler shows the dataManager access in getMateUniqueId() to be a hotpath, so let's cache its reply