### PR TITLE
Reorganize RemoveVanillaSpawns.onEntitySpawn.

### DIFF
--- a/src/main/java/com/animania/common/events/RemoveVanillaSpawns.java
+++ b/src/main/java/com/animania/common/events/RemoveVanillaSpawns.java
@@ -1,9 +1,10 @@
 package com.animania.common.events;
 
-import java.util.List;
+import java.util.Iterator;
 
 import com.animania.config.AnimaniaConfig;
 
+import net.minecraft.world.biome.Biome.SpawnListEntry;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
@@ -15,23 +16,21 @@ public class RemoveVanillaSpawns
 	//Removes initial spawns
 	@SubscribeEvent(priority = EventPriority.NORMAL)
 	public void onEntitySpawn(WorldEvent.PotentialSpawns event) {
-		List spawns = event.getList();
-		for (int i = event.getList().size() - 1; i >= 0; i--) {
-			if (AnimaniaConfig.gameRules.replaceVanillaCows && event.getList().get(i).entityClass.getName().contains("net.minecraft.entity.passive.EntityCow")) {
-				event.getList().remove(i);
-			} else if (AnimaniaConfig.gameRules.replaceVanillaCows && event.getList().get(i).entityClass.getName().contains("net.minecraft.entity.passive.EntityMooshroom")) {
-					event.getList().remove(i);
-			} else if (AnimaniaConfig.gameRules.replaceVanillaChickens && event.getList().get(i).entityClass.getName().contains("net.minecraft.entity.passive.EntityChicken")) {
-				event.getList().remove(i);
-			} else if (AnimaniaConfig.gameRules.replaceVanillaPigs && event.getList().get(i).entityClass.getName().contains("net.minecraft.entity.passive.EntityPig")) {
-				event.getList().remove(i);
-			} else if (AnimaniaConfig.gameRules.replaceVanillaSheep && event.getList().get(i).entityClass.getName().contains("net.minecraft.entity.passive.EntitySheep")) {
-				event.getList().remove(i);
-			} else if (AnimaniaConfig.gameRules.replaceVanillaRabbits && event.getList().get(i).entityClass.getName().contains("net.minecraft.entity.passive.EntityRabbit")) {
-				event.getList().remove(i);
-			} else if (AnimaniaConfig.gameRules.replaceVanillaHorses && event.getList().get(i).entityClass.getName().contains("net.minecraft.entity.passive.EntityHorse")) {
-				event.getList().remove(i);
-			}
+		for(Iterator<SpawnListEntry> iter = event.getList().iterator(); iter.hasNext(); )
+		{
+			String className = iter.next().entityClass.getName();
+			if (AnimaniaConfig.gameRules.replaceVanillaCows && (className.equals("net.minecraft.entity.passive.EntityCow") || className.contains("net.minecraft.entity.passive.EntityMooshroom")))
+				iter.remove();
+			else if (AnimaniaConfig.gameRules.replaceVanillaChickens && className.equals("net.minecraft.entity.passive.EntityChicken"))
+				iter.remove();
+			else if(AnimaniaConfig.gameRules.replaceVanillaPigs && className.equals("net.minecraft.entity.passive.EntityPig"))
+				iter.remove();
+			else if(AnimaniaConfig.gameRules.replaceVanillaSheep && className.equals("net.minecraft.entity.passive.EntitySheep"))
+				iter.remove();
+			else if(AnimaniaConfig.gameRules.replaceVanillaRabbits && className.equals("net.minecraft.entity.passive.EntityRabbit"))
+				iter.remove();
+			else if(AnimaniaConfig.gameRules.replaceVanillaHorses && className.equals("net.minecraft.entity.passive.EntityHorse"))
+				iter.remove();
 		}
 	}
 

--- a/src/main/java/com/animania/common/events/RemoveVanillaSpawns.java
+++ b/src/main/java/com/animania/common/events/RemoveVanillaSpawns.java
@@ -19,7 +19,7 @@ public class RemoveVanillaSpawns
 		for(Iterator<SpawnListEntry> iter = event.getList().iterator(); iter.hasNext(); )
 		{
 			String className = iter.next().entityClass.getName();
-			if (AnimaniaConfig.gameRules.replaceVanillaCows && (className.equals("net.minecraft.entity.passive.EntityCow") || className.contains("net.minecraft.entity.passive.EntityMooshroom")))
+			if (AnimaniaConfig.gameRules.replaceVanillaCows && (className.equals("net.minecraft.entity.passive.EntityCow") || className.equals("net.minecraft.entity.passive.EntityMooshroom")))
 				iter.remove();
 			else if (AnimaniaConfig.gameRules.replaceVanillaChickens && className.equals("net.minecraft.entity.passive.EntityChicken"))
 				iter.remove();


### PR DESCRIPTION
This brings the average execution time of this function from 32us down to <0us (Java Profiler no longer lists it as hotpath).