### PR TITLE
Fix Changeling crash when The One Probe not present

### DIFF
--- a/src/main/java/com/animania/addons/catsdogs/common/block/BlockPetBowl.java
+++ b/src/main/java/com/animania/addons/catsdogs/common/block/BlockPetBowl.java
@@ -4,6 +4,7 @@ import com.animania.addons.catsdogs.common.tileentity.TileEntityPetBowl;
 import com.animania.addons.catsdogs.config.CatsDogsConfig;
 import com.animania.api.interfaces.IFoodProviderBlock;
 import com.animania.common.blocks.AnimaniaContainer;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.compat.top.providers.TOPInfoProvider;
 
@@ -257,6 +258,7 @@ public class BlockPetBowl extends AnimaniaContainer implements IFoodProviderBloc
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data)
 	{
 		TileEntity te = world.getTileEntity(data.getPos());

--- a/src/main/java/com/animania/addons/catsdogs/common/entity/canids/EntityFemaleDogBase.java
+++ b/src/main/java/com/animania/addons/catsdogs/common/entity/canids/EntityFemaleDogBase.java
@@ -12,6 +12,7 @@ import com.animania.api.interfaces.IImpregnable;
 import com.animania.api.interfaces.IMateable;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.generic.GenericBehavior;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.compat.top.providers.entity.TOPInfoProviderMateable;
 import com.animania.config.AnimaniaConfig;
@@ -156,6 +157,7 @@ public class EntityFemaleDogBase extends EntityAnimaniaDog implements TOPInfoPro
 	}
 	
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 

--- a/src/main/java/com/animania/addons/catsdogs/common/entity/felids/EntityQueenBase.java
+++ b/src/main/java/com/animania/addons/catsdogs/common/entity/felids/EntityQueenBase.java
@@ -12,6 +12,7 @@ import com.animania.api.interfaces.IImpregnable;
 import com.animania.api.interfaces.IMateable;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.generic.GenericBehavior;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.compat.top.providers.entity.TOPInfoProviderMateable;
 import com.animania.config.AnimaniaConfig;
@@ -157,6 +158,7 @@ public class EntityQueenBase extends EntityAnimaniaCat implements TOPInfoProvide
 	}
 	
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 

--- a/src/main/java/com/animania/common/blocks/BlockCheeseMold.java
+++ b/src/main/java/com/animania/common/blocks/BlockCheeseMold.java
@@ -2,6 +2,7 @@ package com.animania.common.blocks;
 
 import com.animania.Animania;
 import com.animania.common.handler.BlockHandler;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.handler.ItemHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.common.tileentities.TileEntityCheeseMold;
@@ -282,6 +283,7 @@ public class BlockCheeseMold extends BlockContainer implements TOPInfoProvider
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data)
 	{
 		TileEntity te = world.getTileEntity(data.getPos());

--- a/src/main/java/com/animania/common/blocks/BlockHamsterWheel.java
+++ b/src/main/java/com/animania/common/blocks/BlockHamsterWheel.java
@@ -5,6 +5,7 @@ import com.animania.common.capabilities.CapabilityRefs;
 import com.animania.common.capabilities.ICapabilityPlayer;
 import com.animania.common.entities.rodents.EntityHamster;
 import com.animania.common.handler.BlockHandler;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.handler.ItemHandler;
 import com.animania.common.tileentities.TileEntityHamsterWheel;
 import com.animania.compat.top.providers.TOPInfoProvider;
@@ -156,6 +157,7 @@ public class BlockHamsterWheel extends BlockContainer implements TOPInfoProvider
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data)
 	{
 

--- a/src/main/java/com/animania/common/blocks/BlockInvisiblock.java
+++ b/src/main/java/com/animania/common/blocks/BlockInvisiblock.java
@@ -7,6 +7,7 @@ import javax.annotation.Nullable;
 import com.animania.Animania;
 import com.animania.api.interfaces.IFoodProviderBlock;
 import com.animania.common.handler.BlockHandler;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.tileentities.TileEntityInvisiblock;
 import com.animania.common.tileentities.TileEntityTrough;
 import com.animania.compat.top.providers.TOPInfoProvider;
@@ -374,6 +375,7 @@ public class BlockInvisiblock extends BlockContainer implements TOPInfoProvider,
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data)
 	{
 		TileEntity te = world.getTileEntity(data.getPos());

--- a/src/main/java/com/animania/common/blocks/BlockNest.java
+++ b/src/main/java/com/animania/common/blocks/BlockNest.java
@@ -16,6 +16,7 @@ import com.animania.common.entities.peacocks.EntityPeachickBase;
 import com.animania.common.entities.peacocks.EntityPeacockBase;
 import com.animania.common.entities.peacocks.PeacockType;
 import com.animania.common.handler.BlockHandler;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.common.tileentities.TileEntityNest;
 import com.animania.common.tileentities.TileEntityNest.NestContent;
@@ -220,6 +221,7 @@ public class BlockNest extends BlockContainer implements TOPInfoProvider
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data)
 	{
 		TileEntity te = world.getTileEntity(data.getPos());

--- a/src/main/java/com/animania/common/blocks/BlockTrough.java
+++ b/src/main/java/com/animania/common/blocks/BlockTrough.java
@@ -7,6 +7,7 @@ import javax.annotation.Nullable;
 import com.animania.Animania;
 import com.animania.api.interfaces.IFoodProviderBlock;
 import com.animania.common.handler.BlockHandler;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.common.tileentities.TileEntityTrough;
 import com.animania.compat.top.providers.TOPInfoProvider;
@@ -596,6 +597,7 @@ public class BlockTrough extends BlockContainer implements TOPInfoProvider, IFoo
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data)
 	{
 		TileEntity te = world.getTileEntity(data.getPos());

--- a/src/main/java/com/animania/common/entities/chickens/EntityHenBase.java
+++ b/src/main/java/com/animania/common/entities/chickens/EntityHenBase.java
@@ -9,6 +9,7 @@ import com.animania.common.entities.amphibians.EntityAmphibian;
 import com.animania.common.entities.amphibians.EntityFrogs;
 import com.animania.common.entities.amphibians.EntityToad;
 import com.animania.common.entities.chickens.ai.EntityAIFindNest;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.compat.top.providers.entity.TOPInfoProviderBase;
 import com.animania.config.AnimaniaConfig;
@@ -221,6 +222,7 @@ public class EntityHenBase extends EntityAnimaniaChicken implements TOPInfoProvi
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 		if (player.isSneaking())

--- a/src/main/java/com/animania/common/entities/cows/EntityBullBase.java
+++ b/src/main/java/com/animania/common/entities/cows/EntityBullBase.java
@@ -14,6 +14,7 @@ import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.cows.ai.EntityAIAttackMeleeBulls;
 import com.animania.common.entities.generic.GenericBehavior;
 import com.animania.common.entities.generic.ai.GenericAIMate;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.handler.DamageSourceHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.compat.top.providers.entity.TOPInfoProviderMateable;
@@ -214,6 +215,7 @@ public class EntityBullBase extends EntityAnimaniaCow implements TOPInfoProvider
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 		if (player.isSneaking())

--- a/src/main/java/com/animania/common/entities/cows/EntityCowBase.java
+++ b/src/main/java/com/animania/common/entities/cows/EntityCowBase.java
@@ -11,6 +11,7 @@ import com.animania.api.interfaces.IImpregnable;
 import com.animania.api.interfaces.IMateable;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.generic.GenericBehavior;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.handler.DamageSourceHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.compat.top.providers.entity.TOPInfoProviderMateable;
@@ -247,6 +248,7 @@ public class EntityCowBase extends EntityAnimaniaCow implements TOPInfoProviderM
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 		if (player.isSneaking())

--- a/src/main/java/com/animania/common/entities/goats/EntityBuckBase.java
+++ b/src/main/java/com/animania/common/entities/goats/EntityBuckBase.java
@@ -17,6 +17,7 @@ import com.animania.common.entities.generic.ai.GenericAIMate;
 import com.animania.common.entities.goats.GoatAngora.EntityBuckAngora;
 import com.animania.common.entities.goats.ai.EntityAIButtHeadsGoats;
 import com.animania.common.entities.goats.ai.EntityAIGoatsLeapAtTarget;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.compat.top.providers.entity.TOPInfoProviderMateable;
 import com.animania.config.AnimaniaConfig;
@@ -184,6 +185,7 @@ public class EntityBuckBase extends EntityAnimaniaGoat implements TOPInfoProvide
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 		if (player.isSneaking())

--- a/src/main/java/com/animania/common/entities/goats/EntityDoeBase.java
+++ b/src/main/java/com/animania/common/entities/goats/EntityDoeBase.java
@@ -13,6 +13,7 @@ import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.generic.GenericBehavior;
 import com.animania.common.entities.goats.GoatAngora.EntityDoeAngora;
 import com.animania.common.handler.BlockHandler;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.compat.top.providers.entity.TOPInfoProviderMateable;
 import com.animania.config.AnimaniaConfig;
@@ -223,6 +224,7 @@ public class EntityDoeBase extends EntityAnimaniaGoat implements TOPInfoProvider
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 		if (player.isSneaking())

--- a/src/main/java/com/animania/common/entities/horses/EntityMareBase.java
+++ b/src/main/java/com/animania/common/entities/horses/EntityMareBase.java
@@ -13,6 +13,7 @@ import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.generic.GenericBehavior;
 import com.animania.common.entities.horses.HorseDraft.EntityFoalDraftHorse;
 import com.animania.common.entities.horses.HorseDraft.EntityStallionDraftHorse;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.compat.top.providers.entity.TOPInfoProviderMateable;
 import com.animania.config.AnimaniaConfig;
@@ -288,6 +289,7 @@ public class EntityMareBase extends EntityAnimaniaHorse implements TOPInfoProvid
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 		if (player.isSneaking())

--- a/src/main/java/com/animania/common/entities/peacocks/EntityPeafowlBase.java
+++ b/src/main/java/com/animania/common/entities/peacocks/EntityPeafowlBase.java
@@ -2,6 +2,7 @@ package com.animania.common.entities.peacocks;
 
 import com.animania.api.data.EntityGender;
 import com.animania.common.entities.peacocks.ai.EntityAIFindPeacockNest;
+import com.animania.common.handler.CompatHandler;
 import com.animania.compat.top.providers.entity.TOPInfoProviderBase;
 import com.animania.config.AnimaniaConfig;
 
@@ -112,6 +113,7 @@ public class EntityPeafowlBase extends EntityAnimaniaPeacock implements TOPInfoP
 	}
 	
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 		if (player.isSneaking())

--- a/src/main/java/com/animania/common/entities/pigs/EntityPigletBase.java
+++ b/src/main/java/com/animania/common/entities/pigs/EntityPigletBase.java
@@ -9,6 +9,7 @@ import com.animania.api.interfaces.IChild;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.generic.GenericBehavior;
 import com.animania.common.entities.generic.ai.GenericAIFollowParents;
+import com.animania.common.handler.CompatHandler;
 import com.animania.compat.top.providers.entity.TOPInfoProviderChild;
 import com.google.common.base.Optional;
 
@@ -156,6 +157,7 @@ public class EntityPigletBase extends EntityAnimaniaPig implements TOPInfoProvid
 	}
 	
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 		 if (this.getPlayed())

--- a/src/main/java/com/animania/common/entities/pigs/EntitySowBase.java
+++ b/src/main/java/com/animania/common/entities/pigs/EntitySowBase.java
@@ -11,6 +11,7 @@ import com.animania.api.interfaces.IImpregnable;
 import com.animania.api.interfaces.IMateable;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.generic.GenericBehavior;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.compat.top.providers.entity.TOPInfoProviderPig;
 import com.animania.config.AnimaniaConfig;
@@ -225,6 +226,7 @@ public class EntitySowBase extends EntityAnimaniaPig implements TOPInfoProviderP
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 

--- a/src/main/java/com/animania/common/entities/rodents/rabbits/EntityRabbitBuckBase.java
+++ b/src/main/java/com/animania/common/entities/rodents/rabbits/EntityRabbitBuckBase.java
@@ -13,6 +13,7 @@ import com.animania.api.interfaces.ISterilizable;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.generic.GenericBehavior;
 import com.animania.common.entities.generic.ai.GenericAIMate;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.compat.top.providers.entity.TOPInfoProviderMateable;
 import com.google.common.base.Optional;
@@ -111,6 +112,7 @@ public class EntityRabbitBuckBase extends EntityAnimaniaRabbit implements TOPInf
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 		TOPInfoProviderMateable.super.addProbeInfo(mode, probeInfo, player, world, entity, data);

--- a/src/main/java/com/animania/common/entities/rodents/rabbits/EntityRabbitDoeBase.java
+++ b/src/main/java/com/animania/common/entities/rodents/rabbits/EntityRabbitDoeBase.java
@@ -11,6 +11,7 @@ import com.animania.api.interfaces.IImpregnable;
 import com.animania.api.interfaces.IMateable;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.generic.GenericBehavior;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.compat.top.providers.entity.TOPInfoProviderMateable;
 import com.animania.config.AnimaniaConfig;
@@ -174,6 +175,7 @@ public class EntityRabbitDoeBase extends EntityAnimaniaRabbit implements TOPInfo
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 		if (player.isSneaking())

--- a/src/main/java/com/animania/common/entities/sheep/EntityEweBase.java
+++ b/src/main/java/com/animania/common/entities/sheep/EntityEweBase.java
@@ -12,6 +12,7 @@ import com.animania.api.interfaces.IMateable;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.generic.GenericBehavior;
 import com.animania.common.handler.BlockHandler;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.compat.top.providers.entity.TOPInfoProviderMateable;
 import com.animania.config.AnimaniaConfig;
@@ -205,6 +206,7 @@ public class EntityEweBase extends EntityAnimaniaSheep implements TOPInfoProvide
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 		if (player.isSneaking())

--- a/src/main/java/com/animania/common/entities/sheep/EntityRamBase.java
+++ b/src/main/java/com/animania/common/entities/sheep/EntityRamBase.java
@@ -14,6 +14,7 @@ import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.generic.GenericBehavior;
 import com.animania.common.entities.generic.ai.GenericAIMate;
 import com.animania.common.entities.sheep.ai.EntityAIButtHeadsSheep;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 import com.animania.compat.top.providers.entity.TOPInfoProviderMateable;
 import com.animania.config.AnimaniaConfig;
@@ -169,6 +170,7 @@ public class EntityRamBase extends EntityAnimaniaSheep implements TOPInfoProvide
 	}
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	public void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 		if (player.isSneaking())

--- a/src/main/java/com/animania/common/handler/CompatHandler.java
+++ b/src/main/java/com/animania/common/handler/CompatHandler.java
@@ -5,13 +5,14 @@ import net.minecraftforge.fml.common.event.FMLInterModComms;
 
 public class CompatHandler
 {
+	public static final String THEONEPROBE_ID = "theoneprobe";
 
 	public static void preInit()
 	{
 		if (Loader.isModLoaded("waila"))
 			FMLInterModComms.sendMessage("waila", "register", "com.animania.compat.waila.WailaCompat.registerWaila");
 
-		if (Loader.isModLoaded("theoneprobe"))
+		if (Loader.isModLoaded(THEONEPROBE_ID))
 			FMLInterModComms.sendFunctionMessage("theoneprobe", "getTheOneProbe", "com.animania.compat.top.TOPCompat");
 
 		if (Loader.isModLoaded("morph")) {

--- a/src/main/java/com/animania/compat/top/providers/TOPInfoEntityProvider.java
+++ b/src/main/java/com/animania/compat/top/providers/TOPInfoEntityProvider.java
@@ -1,5 +1,7 @@
 package com.animania.compat.top.providers;
 
+import com.animania.common.handler.CompatHandler;
+
 import mcjty.theoneprobe.api.IProbeHitEntityData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.ProbeMode;
@@ -10,6 +12,7 @@ import net.minecraft.world.World;
 public interface TOPInfoEntityProvider
 {
 
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
     void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data);
 
 }

--- a/src/main/java/com/animania/compat/top/providers/TOPInfoProvider.java
+++ b/src/main/java/com/animania/compat/top/providers/TOPInfoProvider.java
@@ -1,5 +1,7 @@
 package com.animania.compat.top.providers;
 
+import com.animania.common.handler.CompatHandler;
+
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.ProbeMode;
@@ -9,5 +11,6 @@ import net.minecraft.world.World;
 
 public interface TOPInfoProvider
 {
-    void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data);
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
+	void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, IBlockState blockState, IProbeHitData data);
 }

--- a/src/main/java/com/animania/compat/top/providers/entity/TOPInfoProviderBase.java
+++ b/src/main/java/com/animania/compat/top/providers/entity/TOPInfoProviderBase.java
@@ -2,6 +2,7 @@ package com.animania.compat.top.providers.entity;
 
 import com.animania.api.data.EntityGender;
 import com.animania.api.interfaces.IGendered;
+import com.animania.common.handler.CompatHandler;
 import com.animania.compat.top.providers.TOPInfoEntityProvider;
 import com.animania.config.AnimaniaConfig;
 
@@ -19,6 +20,7 @@ public interface TOPInfoProviderBase extends TOPInfoEntityProvider
 {
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	default void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 		NBTTagCompound tag = new NBTTagCompound();

--- a/src/main/java/com/animania/compat/top/providers/entity/TOPInfoProviderChild.java
+++ b/src/main/java/com/animania/compat/top/providers/entity/TOPInfoProviderChild.java
@@ -2,6 +2,7 @@ package com.animania.compat.top.providers.entity;
 
 import java.util.UUID;
 
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 
 import mcjty.theoneprobe.api.IProbeHitEntityData;
@@ -18,6 +19,7 @@ public interface TOPInfoProviderChild extends TOPInfoProviderBase
 {
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	default void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 		TOPInfoProviderBase.super.addProbeInfo(mode, probeInfo, player, world, entity, data);

--- a/src/main/java/com/animania/compat/top/providers/entity/TOPInfoProviderMateable.java
+++ b/src/main/java/com/animania/compat/top/providers/entity/TOPInfoProviderMateable.java
@@ -3,6 +3,7 @@ package com.animania.compat.top.providers.entity;
 import java.util.UUID;
 
 import com.animania.api.interfaces.ISterilizable;
+import com.animania.common.handler.CompatHandler;
 import com.animania.common.helper.AnimaniaHelper;
 
 import mcjty.theoneprobe.api.IProbeHitEntityData;
@@ -19,6 +20,7 @@ public interface TOPInfoProviderMateable extends TOPInfoProviderBase
 {
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	default void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 

--- a/src/main/java/com/animania/compat/top/providers/entity/TOPInfoProviderPig.java
+++ b/src/main/java/com/animania/compat/top/providers/entity/TOPInfoProviderPig.java
@@ -1,5 +1,7 @@
 package com.animania.compat.top.providers.entity;
 
+import com.animania.common.handler.CompatHandler;
+
 import mcjty.theoneprobe.api.IProbeHitEntityData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.ProbeMode;
@@ -14,6 +16,7 @@ public interface TOPInfoProviderPig extends TOPInfoProviderMateable
 {
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	default void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 		NBTTagCompound tag = new NBTTagCompound();

--- a/src/main/java/com/animania/compat/top/providers/entity/TOPInfoProviderRodent.java
+++ b/src/main/java/com/animania/compat/top/providers/entity/TOPInfoProviderRodent.java
@@ -1,5 +1,7 @@
 package com.animania.compat.top.providers.entity;
 
+import com.animania.common.handler.CompatHandler;
+
 import mcjty.theoneprobe.api.IProbeHitEntityData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.ProbeMode;
@@ -14,6 +16,7 @@ public interface TOPInfoProviderRodent extends TOPInfoProviderBase
 {
 
 	@Override
+	@net.minecraftforge.fml.common.Optional.Method(modid=CompatHandler.THEONEPROBE_ID)
 	default void addProbeInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data)
 	{
 


### PR DESCRIPTION
https://github.com/asanetargoss/Changeling/issues/6

Java reflection operations on Animania mob classes or block classes triggers classloading of The One Probe classes during the JVM's normal bytecode verification process. If The One Probe is not present, the JVM complains with NoClassDefFoundError.

Changeling uses Java reflection to allow the player to have the step sounds of the mob they are morphed as, and thus we get NoClassDefFoundError for Animania mobs. Simply catching the exception is not a good alternative, as it prevents the correct mob step sounds from being played.

The fix in this PR is to annotate functions referencing The One Probe with `@Optional` so they do not exist unless The One Probe is present. This has the added benefit of safeguarding Animania from other potential classloading-related crashes, and is good practice in general.

One exception: TOPCompat is left without the `@Optional` annotation, as that class should never be loaded unless The One Probe is actually present.