### PR TITLE
Fix disappearing hamsters and re-roll UUID conflicts

### DIFF
--- a/src/main/java/com/animania/common/blocks/BlockNest.java
+++ b/src/main/java/com/animania/common/blocks/BlockNest.java
@@ -124,7 +124,7 @@ public class BlockNest extends BlockContainer implements TOPInfoProvider
 							ChickenType chickType = ChickenType.breed(rooster.type, birdType);
 							EntityChickBase chick = chickType.getChild(worldIn);
 							chick.setPosition(pos.getX() + .5, pos.getY() + .2, pos.getZ() + .5);
-							worldIn.spawnEntity(chick);
+							AnimaniaHelper.spawnEntity(worldIn, chick);
 							chick.playSound(ModSoundEvents.chickenCluck1, 0.50F, 1.4F);
 							te.removeItem();
 							te.markDirty();
@@ -146,7 +146,7 @@ public class BlockNest extends BlockContainer implements TOPInfoProvider
 							PeacockType chickType = PeacockType.breed(peacock.type, birdType);
 							EntityPeachickBase chick = chickType.getChild(worldIn);
 							chick.setPosition(pos.getX() + .5, pos.getY() + .2, pos.getZ() + .5);
-							worldIn.spawnEntity(chick);
+							AnimaniaHelper.spawnEntity(worldIn, chick);
 							chick.playSound(ModSoundEvents.peacock1, 0.50F, 1.4F);
 							te.removeItem();
 							te.markDirty();

--- a/src/main/java/com/animania/common/entities/chickens/EntityHenBase.java
+++ b/src/main/java/com/animania/common/entities/chickens/EntityHenBase.java
@@ -77,13 +77,13 @@ public class EntityHenBase extends EntityAnimaniaChicken implements TOPInfoProvi
 			{
 				EntityRoosterBase entityChicken = this.type.getMale(world);
 				entityChicken.setPosition(this.posX, this.posY, this.posZ);
-				this.world.spawnEntity(entityChicken);
+				AnimaniaHelper.spawnEntity(this.world, entityChicken);
 			}
 			else if (chooser == 1)
 			{
 				EntityChickBase entityChicken = this.type.getChild(world);
 				entityChicken.setPosition(this.posX, this.posY, this.posZ);
-				this.world.spawnEntity(entityChicken);
+				AnimaniaHelper.spawnEntity(this.world, entityChicken);
 			}
 			
 		}

--- a/src/main/java/com/animania/common/entities/cows/EntityAnimaniaCow.java
+++ b/src/main/java/com/animania/common/entities/cows/EntityAnimaniaCow.java
@@ -231,11 +231,11 @@ public class EntityAnimaniaCow extends EntityCow implements IAnimaniaAnimalBase
 				{
 					entitycow.setCustomNameTag(this.getCustomNameTag());
 				}
-				this.world.spawnEntity(entitycow);
+				AnimaniaHelper.spawnEntity(this.world, entitycow);
 
 				for (int i = 0; i < 5; ++i)
 				{
-					this.world.spawnEntity(new EntityItem(this.world, this.posX, this.posY + (double) this.height, this.posZ, new ItemStack(Blocks.RED_MUSHROOM)));
+					AnimaniaHelper.spawnEntity(this.world, new EntityItem(this.world, this.posX, this.posY + (double) this.height, this.posZ, new ItemStack(Blocks.RED_MUSHROOM)));
 				}
 
 				stack.damageItem(1, player);

--- a/src/main/java/com/animania/common/entities/generic/GenericBehavior.java
+++ b/src/main/java/com/animania/common/entities/generic/GenericBehavior.java
@@ -214,7 +214,7 @@ public class GenericBehavior
 						if (grownUp instanceof IFoodEating)
 							((IFoodEating) grownUp).setInteracted(entity.getInteracted());
 
-						world.spawnEntity(grownUp);
+						AnimaniaHelper.spawnEntity(world, grownUp);
 						grownUp.playLivingSound();
 					}
 
@@ -331,7 +331,7 @@ public class GenericBehavior
 
 					if (!world.isRemote)
 					{
-						world.spawnEntity(entityKid);
+						AnimaniaHelper.spawnEntity(world, entityKid);
 					}
 
 					entity.setPregnant(false);
@@ -448,7 +448,7 @@ public class GenericBehavior
 			if (animal != null)
 			{
 				animal.setPosition(entity.posX, entity.posY, entity.posZ);
-				entity.world.spawnEntity(animal);
+				AnimaniaHelper.spawnEntity(entity.world, animal);
 			}
 		}
 	}

--- a/src/main/java/com/animania/common/entities/peacocks/EntityAnimaniaPeacock.java
+++ b/src/main/java/com/animania/common/entities/peacocks/EntityAnimaniaPeacock.java
@@ -313,7 +313,7 @@ public class EntityAnimaniaPeacock extends EntityAnimal implements TOPInfoProvid
 				{
 					ItemStack item = new ItemStack(feather, 1);
 					EntityItem entityitem = new EntityItem(world, this.posX + 0.5D, this.posY + 0.5D, this.posZ + 0.5D, item);
-					world.spawnEntity(entityitem);
+					AnimaniaHelper.spawnEntity(world, entityitem);
 				}
 			}
 

--- a/src/main/java/com/animania/common/entities/pigs/EntityAnimaniaPig.java
+++ b/src/main/java/com/animania/common/entities/pigs/EntityAnimaniaPig.java
@@ -449,7 +449,7 @@ public class EntityAnimaniaPig extends EntityPig implements IAnimaniaAnimalBase
 				entitypigzombie.setAlwaysRenderNameTag(this.getAlwaysRenderNameTag());
 			}
 
-			this.world.spawnEntity(entitypigzombie);
+			AnimaniaHelper.spawnEntity(world, entitypigzombie);
 			this.setDead();
 		}
 	}

--- a/src/main/java/com/animania/common/entities/rodents/EntityFerretBase.java
+++ b/src/main/java/com/animania/common/entities/rodents/EntityFerretBase.java
@@ -240,7 +240,9 @@ public class EntityFerretBase extends EntityTameable implements TOPInfoProviderR
 				props.setType(EntityList.getKey(this).getResourcePath());
 				this.setDead();
 				player.swingArm(EnumHand.MAIN_HAND);
-				Animania.network.sendToAllAround(new CapSyncPacket(props, player.getEntityId()), new NetworkRegistry.TargetPoint(player.world.provider.getDimension(), player.getPosition().getX(), player.getPosition().getY(), player.getPosition().getZ(), 64));
+				if (!player.world.isRemote) {
+					Animania.network.sendToAllAround(new CapSyncPacket(props, player.getEntityId()), new NetworkRegistry.TargetPoint(player.world.provider.getDimension(), player.getPosition().getX(), player.getPosition().getY(), player.getPosition().getZ(), 64));
+				}
 				return true;
 			}
 		}

--- a/src/main/java/com/animania/common/entities/rodents/EntityHamster.java
+++ b/src/main/java/com/animania/common/entities/rodents/EntityHamster.java
@@ -310,7 +310,9 @@ public class EntityHamster extends EntityTameable implements TOPInfoProviderRode
 				props.setType("hamster");
 				this.setDead();
 				player.swingArm(EnumHand.MAIN_HAND);
-				Animania.network.sendToAllAround(new CapSyncPacket(props, player.getEntityId()), new NetworkRegistry.TargetPoint(player.world.provider.getDimension(), player.getPosition().getX(), player.getPosition().getY(), player.getPosition().getZ(), 64));
+				if (!player.world.isRemote) {
+					Animania.network.sendToAllAround(new CapSyncPacket(props, player.getEntityId()), new NetworkRegistry.TargetPoint(player.world.provider.getDimension(), player.getPosition().getX(), player.getPosition().getY(), player.getPosition().getZ(), 64));
+				}
 				return true;
 			}
 

--- a/src/main/java/com/animania/common/entities/rodents/EntityHedgehogBase.java
+++ b/src/main/java/com/animania/common/entities/rodents/EntityHedgehogBase.java
@@ -327,7 +327,9 @@ public class EntityHedgehogBase extends EntityTameable implements TOPInfoProvide
 				props.setType(EntityList.getKey(this).getResourcePath());
 				this.setDead();
 				player.swingArm(EnumHand.MAIN_HAND);
-				Animania.network.sendToAllAround(new CapSyncPacket(props, player.getEntityId()), new NetworkRegistry.TargetPoint(player.world.provider.getDimension(), player.getPosition().getX(), player.getPosition().getY(), player.getPosition().getZ(), 64));
+				if (!player.world.isRemote) {
+					Animania.network.sendToAllAround(new CapSyncPacket(props, player.getEntityId()), new NetworkRegistry.TargetPoint(player.world.provider.getDimension(), player.getPosition().getX(), player.getPosition().getY(), player.getPosition().getZ(), 64));
+				}
 				return true;
 			}
 		}

--- a/src/main/java/com/animania/common/events/InteractHandler.java
+++ b/src/main/java/com/animania/common/events/InteractHandler.java
@@ -195,7 +195,7 @@ public class InteractHandler
 					BlockPos pos = event.getPos();
 					e.setPosition(pos.getX() + 0.5, pos.getY() + 1, pos.getZ() + 0.5);
 					
-					event.getWorld().spawnEntity(e);
+					AnimaniaHelper.spawnEntity(world, e);
 				}
 	
 				props.setAnimal(new NBTTagCompound());

--- a/src/main/java/com/animania/common/events/InteractHandler.java
+++ b/src/main/java/com/animania/common/events/InteractHandler.java
@@ -181,26 +181,40 @@ public class InteractHandler
 		World world = event.getWorld();
 
 		if (props.isCarrying() && player.isSneaking())
-		{
-			Entity e = null;
-
-			e = EntityList.createEntityByIDFromName(new ResourceLocation(Animania.MODID, props.getType()), world);
-			e.readFromNBT(props.getAnimal());
-
-			if (e != null)
+		{		
+			player.swingArm(EnumHand.MAIN_HAND);
+			player.playSound(SoundEvents.ENTITY_ITEM_PICKUP, 1.0F, (Animania.RANDOM.nextFloat() - Animania.RANDOM.nextFloat()) * 0.2F + 1.0F);
+			
+			if (!world.isRemote)
 			{
-				BlockPos pos = event.getPos();
-				e.setPosition(pos.getX() + 0.5, pos.getY() + 1, pos.getZ() + 0.5);
-				if (!world.isRemote)
+				Entity e = EntityList.createEntityByIDFromName(new ResourceLocation(Animania.MODID, props.getType()), world);
+
+				if (e != null) {
+					e.readFromNBT(props.getAnimal());
+					
+					BlockPos pos = event.getPos();
+					e.setPosition(pos.getX() + 0.5, pos.getY() + 1, pos.getZ() + 0.5);
+					
 					event.getWorld().spawnEntity(e);
+				}
+	
 				props.setAnimal(new NBTTagCompound());
 				props.setCarrying(false);
 				props.setType("");
-				player.swingArm(EnumHand.MAIN_HAND);
-				player.playSound(SoundEvents.ENTITY_ITEM_PICKUP, 1.0F, (Animania.RANDOM.nextFloat() - Animania.RANDOM.nextFloat()) * 0.2F + 1.0F);
-				event.setCanceled(true);
-				Animania.network.sendToAllAround(new CapSyncPacket(props, player.getEntityId()), new NetworkRegistry.TargetPoint(player.world.provider.getDimension(), player.getPosition().getX(), player.getPosition().getY(), player.getPosition().getZ(), 64));
+				
+				Animania.network.sendToAllAround(
+					new CapSyncPacket(props, player.getEntityId())
+					, new NetworkRegistry.TargetPoint(
+						player.world.provider.getDimension()
+						, player.getPosition().getX()
+						, player.getPosition().getY()
+						, player.getPosition().getZ()
+						, 64
+					)
+				);
 			}
+			
+			event.setCanceled(true);
 		}
 	}
 

--- a/src/main/java/com/animania/common/events/SpawnHandler.java
+++ b/src/main/java/com/animania/common/events/SpawnHandler.java
@@ -560,7 +560,7 @@ public class SpawnHandler
 		if (replacementEntity != null)
 		{
 			replacementEntity.setPosition(event.getX(), event.getY(), event.getZ());
-			event.getWorld().spawnEntity(replacementEntity);
+			AnimaniaHelper.spawnEntity(worldIn, replacementEntity);
 		}
 	}
 

--- a/src/main/java/com/animania/common/handler/DispenserHandler.java
+++ b/src/main/java/com/animania/common/handler/DispenserHandler.java
@@ -10,6 +10,7 @@ import com.animania.common.entities.goats.GoatType;
 import com.animania.common.entities.peacocks.PeacockType;
 import com.animania.common.entities.pigs.PigType;
 import com.animania.common.entities.rodents.rabbits.RabbitType;
+import com.animania.common.helper.AnimaniaHelper;
 import com.animania.common.items.ItemEntityEgg;
 import com.animania.config.AnimaniaConfig;
 
@@ -167,7 +168,7 @@ public class DispenserHandler
 				// ((rand.nextFloat() - rand.nextFloat()) * 0.2F + 1.0F) /
 				// 0.8F);
 
-				world.spawnEntity(entity);
+				AnimaniaHelper.spawnEntity(world, entity);
 			}
 
 			return stack;

--- a/src/main/java/com/animania/common/helper/AnimaniaHelper.java
+++ b/src/main/java/com/animania/common/helper/AnimaniaHelper.java
@@ -44,11 +44,13 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
 import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.common.BiomeDictionary.Type;
@@ -529,5 +531,20 @@ public class AnimaniaHelper
 		}
 		
 		return false;
+	}
+	
+	/* 
+	 * Spawns entity and ensures the unique UUID.
+	 * Does not re-roll the UUID on remote worlds.
+	 */
+	public static boolean spawnEntity(World world, Entity entity) {
+		if (!world.isRemote) {
+			WorldServer ws = (WorldServer)world;
+			while (ws.getEntityFromUuid(entity.getUniqueID()) != null) {
+				entity.setUniqueId(MathHelper.getRandomUUID(Animania.RANDOM));
+			}
+		}
+		
+		return world.spawnEntity(entity);
 	}
 }

--- a/src/main/java/com/animania/common/helper/ItemHelper.java
+++ b/src/main/java/com/animania/common/helper/ItemHelper.java
@@ -50,7 +50,7 @@ public class ItemHelper
 		EntityItem item = new EntityItem(world);
 		item.setPosition(pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5);
 		item.setItem(itemStack);
-		world.spawnEntity(item);
+		AnimaniaHelper.spawnEntity(world, item);
 	}
 	
 	public static int getSlotForItem(Item item, EntityPlayer player)

--- a/src/main/java/com/animania/common/items/ItemBrownEgg.java
+++ b/src/main/java/com/animania/common/items/ItemBrownEgg.java
@@ -1,6 +1,7 @@
 package com.animania.common.items;
 
 import com.animania.Animania;
+import com.animania.common.helper.AnimaniaHelper;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.projectile.EntityEgg;
@@ -49,7 +50,7 @@ public class ItemBrownEgg extends Item
         if (!worldIn.isRemote) {
             EntityEgg entityegg = new EntityEgg(worldIn, playerIn);
             entityegg.shoot(playerIn, playerIn.rotationPitch, playerIn.rotationYaw, 0.0F, 1.5F, 1.0F);
-            worldIn.spawnEntity(entityegg);
+            AnimaniaHelper.spawnEntity(worldIn, entityegg);
         }
 
         playerIn.addStat(StatList.getObjectUseStats(this));

--- a/src/main/java/com/animania/common/items/ItemCart.java
+++ b/src/main/java/com/animania/common/items/ItemCart.java
@@ -3,6 +3,7 @@ package com.animania.common.items;
 import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.props.EntityCart;
+import com.animania.common.helper.AnimaniaHelper;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
@@ -133,7 +134,7 @@ public class ItemCart extends Item
 		world.playSound(null, playerIn.posX, playerIn.posY, playerIn.posZ, ModSoundEvents.combo, SoundCategory.PLAYERS, 0.8F, ((Animania.RANDOM.nextFloat() - Animania.RANDOM.nextFloat()) * 0.2F + 1.0F) / 0.8F);
 		entity.rotationYaw = entity.rotationYaw;
 		entity.deltaRotation = entity.rotationYaw;
-		world.spawnEntity(entity);
+		AnimaniaHelper.spawnEntity(world, entity);
 		return EnumActionResult.SUCCESS;
 
 	}

--- a/src/main/java/com/animania/common/items/ItemEntityEgg.java
+++ b/src/main/java/com/animania/common/items/ItemEntityEgg.java
@@ -12,6 +12,7 @@ import com.animania.api.interfaces.IFoodEating;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.RandomAnimalType;
 import com.animania.common.handler.ItemHandler;
+import com.animania.common.helper.AnimaniaHelper;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.color.IItemColor;
@@ -109,7 +110,7 @@ public class ItemEntityEgg extends Item
 				foodEating.setInteracted(true);
 			}
 			
-			world.spawnEntity(entity);
+			AnimaniaHelper.spawnEntity(world, entity);
 			return EnumActionResult.SUCCESS;
 
 		}

--- a/src/main/java/com/animania/common/items/ItemMilkBottle.java
+++ b/src/main/java/com/animania/common/items/ItemMilkBottle.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import com.animania.common.helper.AnimaniaHelper;
 import com.animania.config.AnimaniaConfig;
 
 import net.minecraft.client.util.ITooltipFlag;
@@ -49,7 +50,7 @@ public class ItemMilkBottle extends ItemAnimaniaFood
 				if (!worldIn.isRemote)
 				{
 					EntityItem entityitem = new EntityItem(worldIn, entityLiving.posX + 0.5D, entityLiving.posY + 0.5D, entityLiving.posZ + 0.5D, new ItemStack(Items.GLASS_BOTTLE));
-					worldIn.spawnEntity(entityitem);
+					AnimaniaHelper.spawnEntity(worldIn, entityitem);
 				}
 
 				if (entityPlayer.getFoodStats() != null)

--- a/src/main/java/com/animania/common/items/ItemTiller.java
+++ b/src/main/java/com/animania/common/items/ItemTiller.java
@@ -3,6 +3,7 @@ package com.animania.common.items;
 import com.animania.Animania;
 import com.animania.common.ModSoundEvents;
 import com.animania.common.entities.props.EntityTiller;
+import com.animania.common.helper.AnimaniaHelper;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
@@ -52,7 +53,7 @@ public class ItemTiller extends Item
 		world.playSound(null, playerIn.posX, playerIn.posY, playerIn.posZ, ModSoundEvents.combo, SoundCategory.PLAYERS, 0.8F, ((Animania.RANDOM.nextFloat() - Animania.RANDOM.nextFloat()) * 0.2F + 1.0F) / 0.8F);
 		entity.rotationYaw = entity.rotationYaw;
 		entity.deltaRotation = entity.rotationYaw;
-		world.spawnEntity(entity);
+		AnimaniaHelper.spawnEntity(world, entity);
 		return EnumActionResult.SUCCESS;
 
 	}

--- a/src/main/java/com/animania/common/items/ItemWagon.java
+++ b/src/main/java/com/animania/common/items/ItemWagon.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.animania.Animania;
 import com.animania.common.entities.props.EntityWagon;
+import com.animania.common.helper.AnimaniaHelper;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
@@ -98,7 +99,7 @@ public class ItemWagon extends Item
 
 				if (!worldIn.isRemote)
 				{
-					worldIn.spawnEntity(EntityWagon);
+					AnimaniaHelper.spawnEntity(worldIn, EntityWagon);
 				}
 
 				if (!playerIn.capabilities.isCreativeMode)

--- a/src/main/java/com/animania/common/tileentities/TileEntityHamsterWheel.java
+++ b/src/main/java/com/animania/common/tileentities/TileEntityHamsterWheel.java
@@ -173,7 +173,7 @@ public class TileEntityHamsterWheel extends AnimatedTileEntity implements ITicka
 		{
 			if (findPositionForHamster())
 			{
-				world.spawnEntity(hamster);
+				AnimaniaHelper.spawnEntity(world, hamster);
 				hamster.playSound(SoundEvents.ENTITY_ITEM_PICKUP, 1.0F, (Animania.RANDOM.nextFloat() - Animania.RANDOM.nextFloat()) * 0.2F + 1.0F);
 				// this.hamster.setWatered(false);
 				this.hamster.setFed(false);


### PR DESCRIPTION
Definitely fixes #164 
Might be a potential fix for #77, further testing required

The first commit fixes hamsters and other carriable mobs getting desynced on servers by executing code on proper sides.

The second commit replaces all occurrences of `world.spawnEntity(entity)` with `AnimaniaHelper.spawnEntity(world, entity)` which resolves UUID conflicts before animals get spawned, which also coincidentally fixes spontaneous carriable mobs disappearances.